### PR TITLE
Correction: smooth reference times were swapped for joints and feet

### DIFF
--- a/controllers/torqueWalkingMPC/src/controller/QPBalancingMPC.m
+++ b/controllers/torqueWalkingMPC/src/controller/QPBalancingMPC.m
@@ -245,9 +245,7 @@ function QPBalancingMPC(block)
         
         % to avoid the equality constraints to be unfeasible for numerical 
         % errors, a small tolerance is added to the bias vectors
-        eps      = [0.0001*ones(3,1); 0.0001*ones(3,1); ...
-                    0.0001*ones(3,1); 0.0001*ones(3,1); ...
-                    0.0001*ones(3,1); 0.0001*ones(3,1)];
+       	eps = 0.0001*ones(size(biasVectorConstraint_equality,1),1);
                 
         % upper bound constraints    
         ubA  = [biasVectorConstraint_inequality;

--- a/controllers/torqueWalkingMPC/torqueWalkingMPC.mdl
+++ b/controllers/torqueWalkingMPC/torqueWalkingMPC.mdl
@@ -1,12 +1,12 @@
 Model {
-  Name			  "torqueWalkingMPC"
+  Name			  "torqueWalkingMPC_2016b"
   Version		  8.8
   SavedCharacterEncoding  "UTF-8"
   GraphicalInterface {
     NumRootInports	    0
     NumRootOutports	    0
     ParameterArgumentNames  ""
-    ComputedModelVersion    "1.504"
+    ComputedModelVersion    "1.506"
     NumModelReferences	    0
     NumTestPointedSignals   0
     NumProvidedFunctions    0
@@ -20,7 +20,7 @@ Model {
   LogicAnalyzerPlugin	  "on"
   LogicAnalyzerSignalOrdering ""
   DiagnosticSuppressor	  "on"
-  SuppressorTable	  "22 serialization::archive 11 0 3 0 0 0 11 0"
+  SuppressorTable	  "22 serialization::archive 11 0 6 0 0 0 11 0"
   ScopeRefreshTime	  0.035000
   OverrideScopeRefreshTime on
   DisableAllScopes	  off
@@ -41,7 +41,7 @@ Model {
       $ObjectID		      2
       $ClassName	      "Simulink.WindowInfo"
       IsActive		      [1]
-      Location		      [65.0, 24.0, 1855.0, 1056.0]
+      Location		      [61.0, 35.0, 1855.0, 1056.0]
       Object {
 	$PropName		"ModelBrowserInfo"
 	$ObjectID		3
@@ -63,21 +63,21 @@ Model {
 	Dimension		2
 	Object {
 	  $ObjectID		  5
-	  IsActive		  [0]
-	  ViewObjType		  "SimulinkTopLevel"
-	  LoadSaveID		  "0"
-	  Extents		  [1821.0, 905.0]
-	  ZoomFactor		  [1.2050300656648256]
-	  Offset		  [-335.58280738636108, -60.379767408639168]
+	  IsActive		  [1]
+	  ViewObjType		  "SimulinkSubsys"
+	  LoadSaveID		  "4624"
+	  Extents		  [1817.0, 871.0]
+	  ZoomFactor		  [1.25]
+	  Offset		  [-115.24858900419049, 140.52397110896351]
 	}
 	Object {
 	  $ObjectID		  6
-	  IsActive		  [1]
+	  IsActive		  [0]
 	  ViewObjType		  "SimulinkSubsys"
 	  LoadSaveID		  "4470"
-	  Extents		  [1821.0, 905.0]
+	  Extents		  [1817.0, 871.0]
 	  ZoomFactor		  [1.3218562874251496]
-	  Offset		  [495.7545167398074, 405.4088335220838]
+	  Offset		  [495.75451673980751, 405.4088335220838]
 	}
 	PropName		"EditorsInfo"
       }
@@ -97,24 +97,24 @@ Model {
       }
       WindowState	      "AAAA/wAAAAD9AAAAAgAAAAAAAAC9AAAB+PwCAAAAA/sAAAAWAEQAbwBjAGsAVwBpAGQAZwBlAHQAMwEAAAAxAAAB+AAAA"
       "AAAAAAA+wAAABYARABvAGMAawBXAGkAZABnAGUAdAA0AAAAAAD/////AAAAAAAAAAD7AAAAUgBHAEwAVQBFADIAIAB0AHIAZQBlACAAYwBvAG0Ac"
-      "ABvAG4AZQBuAHQALwBHAEwAVQBFADIAIAB0AHIAZQBlACAAYwBvAG0AcABvAG4AZQBuAHQAAAAAAP////8AAABeAP///wAAAAEAAAAAAAAAAPwCA"
+      "ABvAG4AZQBuAHQALwBHAEwAVQBFADIAIAB0AHIAZQBlACAAYwBvAG0AcABvAG4AZQBuAHQAAAAAAP////8AAABiAP///wAAAAEAAAAAAAAAAPwCA"
       "AAAAfsAAABUAEcATABVAEUAMgA6AFAAcgBvAHAAZQByAHQAeQBJAG4AcwBwAGUAYwB0AG8AcgAvAFAAcgBvAHAAZQByAHQAeQAgAEkAbgBzAHAAZ"
-      "QBjAHQAbwByAAAAAAD/////AAAAKAD///8AAAc/AAADyQAAAAEAAAACAAAAAQAAAAL8AAAAAQAAAAIAAAAP/////wAAAAAA/////wAAAAAAAAAA/"
+      "QBjAHQAbwByAAAAAAD/////AAAALAD///8AAAc/AAADqwAAAAEAAAACAAAAAQAAAAL8AAAAAQAAAAIAAAAP/////wAAAAAA/////wAAAAAAAAAA/"
       "////wEAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/"
       "////wEAAACA/////wAAAAAAAAAA/////wEAAADo/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wEAAAFo/////wAAAAAAAAAA/"
-      "////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wEAAANR/////wAAAAAAAAAA/"
-      "////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA"
+      "////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wEAAAOH/////wAAAAAAAAAA/"
+      "////wEAAAO5/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA"
     }
   }
   Created		  "Wed Nov 29 15:01:02 2017"
   Creator		  "gnava"
   UpdateHistory		  "UpdateHistoryNever"
   ModifiedByFormat	  "%<Auto>"
-  LastModifiedBy	  "gnava"
+  LastModifiedBy	  "mcharbonneau"
   ModifiedDateFormat	  "%<Auto>"
-  LastModifiedDate	  "Fri Jan 19 16:51:13 2018"
-  RTWModifiedTimeStamp	  438281381
-  ModelVersionFormat	  "1.%<AutoIncrement:504>"
+  LastModifiedDate	  "Thu Feb 22 13:18:33 2018"
+  RTWModifiedTimeStamp	  441206312
+  ModelVersionFormat	  "1.%<AutoIncrement:506>"
   ConfigurationManager	  "none"
   SampleTimeColors	  off
   SampleTimeAnnotations	  off
@@ -164,12 +164,12 @@ Model {
     $PropName		    "DataLoggingOverride"
     $ObjectID		    8
     $ClassName		    "Simulink.SimulationData.ModelLoggingInfo"
-    model_		    "torqueWalkingMPC"
+    model_		    "torqueWalkingMPC_2016b"
     overrideMode_	    [0.0]
     Array {
       Type		      "Cell"
       Dimension		      1
-      Cell		      "torqueWalkingMPC"
+      Cell		      "torqueWalkingMPC_2016b"
       PropName		      "logAsSpecifiedByModels_"
     }
     Array {
@@ -754,7 +754,6 @@ Model {
 	      CodeReplacementLibrary  "None"
 	      UtilityFuncGeneration   "Auto"
 	      ERTMultiwordTypeDef     "System defined"
-	      ERTMultiwordLength      256
 	      MultiwordLength	      2048
 	      GenerateFullHeader      on
 	      InferredTypesCompatibility off
@@ -861,7 +860,7 @@ Model {
       Name		      "Configuration"
       ExtraOptions	      ""
       CurrentDlgPage	      "Solver"
-      ConfigPrmDlgPosition     [ 81, 81, 951, 689 ] 
+      ConfigPrmDlgPosition    [ 81, 81, 951, 689 ]
     }
     PropName		    "ConfigurationSets"
   }
@@ -1056,7 +1055,6 @@ Model {
     }
     Block {
       BlockType		      M-S-Function
-      FunctionName	      "matlabfile"
       DisplayMFileStacktrace  on
     }
     Block {
@@ -1085,6 +1083,7 @@ Model {
       SourceOfInitialOutputValue "Dialog"
       OutputWhenDisabled      "held"
       InitialOutput	      "[]"
+      MustResolveToSignalObject	off
     }
     Block {
       BlockType		      PermuteDimensions
@@ -1214,9 +1213,9 @@ Model {
     }
   }
   System {
-    Name		    "torqueWalkingMPC"
-    Location		    [65, 24, 1920, 1080]
-    Open		    on
+    Name		    "torqueWalkingMPC_2016b"
+    Location		    [61, 35, 1916, 1091]
+    Open		    off
     ModelBrowserVisibility  off
     ModelBrowserWidth	    200
     ScreenColor		    "white"
@@ -1427,7 +1426,7 @@ Model {
 	    TiledPageScale	    1
 	    ShowPageBoundaries	    off
 	    ZoomFactor		    "100"
-	    SIDHighWatermark	    "89"
+	    SIDHighWatermark	    "92"
 	    Block {
 	      BlockType		      Inport
 	      Name		      "feetInContact"
@@ -1565,69 +1564,57 @@ Model {
 	    Block {
 	      BlockType		      Demux
 	      Name		      " Demux "
-	      SID		      "4109::88"
+	      SID		      "4109::91"
 	      Ports		      [1, 1]
 	      Position		      [270, 350, 320, 390]
-	      ZOrder		      78
+	      ZOrder		      81
 	      Outputs		      "1"
 	    }
 	    Block {
 	      BlockType		      S-Function
 	      Name		      " SFunction "
-	      SID		      "4109::87"
-	      Tag		      "Stateflow S-Function torqueWalkingMPC 2"
+	      SID		      "4109::90"
+	      Tag		      "Stateflow S-Function torqueWalkingMPC_2016b 2"
 	      Ports		      [15, 7]
 	      Position		      [180, 85, 230, 405]
-	      ZOrder		      77
+	      ZOrder		      80
 	      FunctionName	      "sf_sfun"
 	      Parameters	      "Sat"
 	      PortCounts	      "[15 7]"
 	      SFunctionDeploymentMode off
-	      EnableBusSupport	      on
+	      EnableBusSupport	      off
 	      SFcnIsStateOwnerBlock   off
 	      Port {
 		PortNumber		2
 		Name			"Hessian"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"gradient"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"ConstraintMatrix_equality"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"biasVectorConstraint_equality"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		6
 		Name			"ConstraintMatrix_inequality"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		7
 		Name			"biasVectorConstraint_inequality"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
 	      BlockType		      Terminator
 	      Name		      " Terminator "
-	      SID		      "4109::89"
+	      SID		      "4109::92"
 	      Position		      [460, 361, 480, 379]
-	      ZOrder		      79
+	      ZOrder		      82
 	    }
 	    Block {
 	      BlockType		      Outport
@@ -1683,105 +1670,105 @@ Model {
 	      IconDisplay	      "Port number"
 	    }
 	    Line {
-	      ZOrder		      139
+	      ZOrder		      162
 	      SrcBlock		      "feetInContact"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      1
 	    }
 	    Line {
-	      ZOrder		      140
+	      ZOrder		      163
 	      SrcBlock		      "M"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      2
 	    }
 	    Line {
-	      ZOrder		      141
+	      ZOrder		      164
 	      SrcBlock		      "h"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      3
 	    }
 	    Line {
-	      ZOrder		      142
+	      ZOrder		      165
 	      SrcBlock		      "J"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      4
 	    }
 	    Line {
-	      ZOrder		      143
+	      ZOrder		      166
 	      SrcBlock		      "impedances"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      5
 	    }
 	    Line {
-	      ZOrder		      144
+	      ZOrder		      167
 	      SrcBlock		      "dampings"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      6
 	    }
 	    Line {
-	      ZOrder		      145
+	      ZOrder		      168
 	      SrcBlock		      "s"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      7
 	    }
 	    Line {
-	      ZOrder		      146
+	      ZOrder		      169
 	      SrcBlock		      "sDot"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      8
 	    }
 	    Line {
-	      ZOrder		      147
+	      ZOrder		      170
 	      SrcBlock		      "s_sDot_sDDot_des"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      9
 	    }
 	    Line {
-	      ZOrder		      148
+	      ZOrder		      171
 	      SrcBlock		      "acc_task_star"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      10
 	    }
 	    Line {
-	      ZOrder		      149
+	      ZOrder		      172
 	      SrcBlock		      "JDot_nu"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      11
 	    }
 	    Line {
-	      ZOrder		      150
+	      ZOrder		      173
 	      SrcBlock		      "ConstraintsMatrix_feet"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      12
 	    }
 	    Line {
-	      ZOrder		      151
+	      ZOrder		      174
 	      SrcBlock		      "biasVectorConstraint_feet"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      13
 	    }
 	    Line {
-	      ZOrder		      152
+	      ZOrder		      175
 	      SrcBlock		      "w_H_l_sole"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      14
 	    }
 	    Line {
-	      ZOrder		      153
+	      ZOrder		      176
 	      SrcBlock		      "w_H_r_sole"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
@@ -1789,7 +1776,7 @@ Model {
 	    }
 	    Line {
 	      Name		      "Hessian"
-	      ZOrder		      154
+	      ZOrder		      177
 	      Labels		      [0, 0]
 	      SrcBlock		      " SFunction "
 	      SrcPort		      2
@@ -1798,7 +1785,7 @@ Model {
 	    }
 	    Line {
 	      Name		      "gradient"
-	      ZOrder		      155
+	      ZOrder		      178
 	      Labels		      [0, 0]
 	      SrcBlock		      " SFunction "
 	      SrcPort		      3
@@ -1807,7 +1794,7 @@ Model {
 	    }
 	    Line {
 	      Name		      "ConstraintMatrix_equality"
-	      ZOrder		      156
+	      ZOrder		      179
 	      Labels		      [0, 0]
 	      SrcBlock		      " SFunction "
 	      SrcPort		      4
@@ -1816,7 +1803,7 @@ Model {
 	    }
 	    Line {
 	      Name		      "biasVectorConstraint_equality"
-	      ZOrder		      157
+	      ZOrder		      180
 	      Labels		      [0, 0]
 	      SrcBlock		      " SFunction "
 	      SrcPort		      5
@@ -1825,7 +1812,7 @@ Model {
 	    }
 	    Line {
 	      Name		      "ConstraintMatrix_inequality"
-	      ZOrder		      158
+	      ZOrder		      181
 	      Labels		      [0, 0]
 	      SrcBlock		      " SFunction "
 	      SrcPort		      6
@@ -1834,7 +1821,7 @@ Model {
 	    }
 	    Line {
 	      Name		      "biasVectorConstraint_inequality"
-	      ZOrder		      159
+	      ZOrder		      182
 	      Labels		      [0, 0]
 	      SrcBlock		      " SFunction "
 	      SrcPort		      7
@@ -1842,14 +1829,14 @@ Model {
 	      DstPort		      1
 	    }
 	    Line {
-	      ZOrder		      160
+	      ZOrder		      183
 	      SrcBlock		      " Demux "
 	      SrcPort		      1
 	      DstBlock		      " Terminator "
 	      DstPort		      1
 	    }
 	    Line {
-	      ZOrder		      161
+	      ZOrder		      184
 	      SrcBlock		      " SFunction "
 	      SrcPort		      1
 	      DstBlock		      " Demux "
@@ -3704,7 +3691,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "22"
+		    SIDHighWatermark	    "25"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "M"
@@ -3716,39 +3703,37 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "6165::20"
+		    SID			    "6165::24"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    11
+		    ZOrder		    14
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "6165::19"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 20"
+		    SID			    "6165::23"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 20"
 		    Ports		    [1, 2]
 		    Position		    [180, 100, 230, 160]
-		    ZOrder		    10
+		    ZOrder		    13
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Config"
 		    PortCounts		    "[1 2]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "M_with_inertia"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "6165::21"
+		    SID			    "6165::25"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    12
+		    ZOrder		    15
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -3759,7 +3744,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    1
+		    ZOrder		    5
 		    SrcBlock		    "M"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -3767,7 +3752,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "M_with_inertia"
-		    ZOrder		    2
+		    ZOrder		    6
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -3775,14 +3760,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    3
+		    ZOrder		    7
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    4
+		    ZOrder		    8
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -4745,7 +4730,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "3746"
+		    SIDHighWatermark	    "3749"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "J_LeftFoot"
@@ -4784,39 +4769,37 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "5626::3745"
+		    SID			    "5626::3748"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    114
+		    ZOrder		    117
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "5626::3744"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 1"
+		    SID			    "5626::3747"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 1"
 		    Ports		    [4, 2]
 		    Position		    [180, 102, 230, 203]
-		    ZOrder		    113
+		    ZOrder		    116
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Sat"
 		    PortCounts		    "[4 2]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "nu_b"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "5626::3746"
+		    SID			    "5626::3749"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    115
+		    ZOrder		    118
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -4827,28 +4810,28 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    43
+		    ZOrder		    50
 		    SrcBlock		    "J_LeftFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    44
+		    ZOrder		    51
 		    SrcBlock		    "J_RightFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    45
+		    ZOrder		    52
 		    SrcBlock		    "feetInContact"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    46
+		    ZOrder		    53
 		    SrcBlock		    "sDot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -4856,7 +4839,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "nu_b"
-		    ZOrder		    47
+		    ZOrder		    54
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -4864,14 +4847,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    48
+		    ZOrder		    55
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    49
+		    ZOrder		    56
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -5473,7 +5456,7 @@ Model {
 		TiledPageScale		1
 		ShowPageBoundaries	off
 		ZoomFactor		"100"
-		SIDHighWatermark	"79"
+		SIDHighWatermark	"82"
 		Block {
 		  BlockType		  Inport
 		  Name			  "pos_vel_acc_CoM_des"
@@ -5593,39 +5576,37 @@ Model {
 		Block {
 		  BlockType		  Demux
 		  Name			  " Demux "
-		  SID			  "4279::78"
+		  SID			  "4279::81"
 		  Ports			  [1, 1]
 		  Position		  [270, 230, 320, 270]
-		  ZOrder		  68
+		  ZOrder		  71
 		  Outputs		  "1"
 		}
 		Block {
 		  BlockType		  S-Function
 		  Name			  " SFunction "
-		  SID			  "4279::77"
-		  Tag			  "Stateflow S-Function torqueWalkingMPC 3"
+		  SID			  "4279::80"
+		  Tag			  "Stateflow S-Function torqueWalkingMPC_2016b 3"
 		  Ports			  [13, 2]
 		  Position		  [180, 90, 230, 370]
-		  ZOrder		  67
+		  ZOrder		  70
 		  FunctionName		  "sf_sfun"
 		  Parameters		  "Sat"
 		  PortCounts		  "[13 2]"
 		  SFunctionDeploymentMode off
-		  EnableBusSupport	  on
+		  EnableBusSupport	  off
 		  SFcnIsStateOwnerBlock	  off
 		  Port {
 		    PortNumber		    2
 		    Name		    "acc_task_star"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
 		  BlockType		  Terminator
 		  Name			  " Terminator "
-		  SID			  "4279::79"
+		  SID			  "4279::82"
 		  Position		  [460, 241, 480, 259]
-		  ZOrder		  69
+		  ZOrder		  72
 		}
 		Block {
 		  BlockType		  Outport
@@ -5636,91 +5617,91 @@ Model {
 		  IconDisplay		  "Port number"
 		}
 		Line {
-		  ZOrder		  97
+		  ZOrder		  113
 		  SrcBlock		  "pos_vel_acc_CoM_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  98
+		  ZOrder		  114
 		  SrcBlock		  "pose_vel_acc_LFoot_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  2
 		}
 		Line {
-		  ZOrder		  99
+		  ZOrder		  115
 		  SrcBlock		  "pose_vel_acc_RFoot_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  3
 		}
 		Line {
-		  ZOrder		  100
+		  ZOrder		  116
 		  SrcBlock		  "orient_vel_acc_rot_task_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  4
 		}
 		Line {
-		  ZOrder		  101
+		  ZOrder		  117
 		  SrcBlock		  "pos_vel_CoM"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  5
 		}
 		Line {
-		  ZOrder		  102
+		  ZOrder		  118
 		  SrcBlock		  "pose_vel_LFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  6
 		}
 		Line {
-		  ZOrder		  103
+		  ZOrder		  119
 		  SrcBlock		  "pose_vel_RFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  7
 		}
 		Line {
-		  ZOrder		  104
+		  ZOrder		  120
 		  SrcBlock		  "orient_vel_rot_task"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  8
 		}
 		Line {
-		  ZOrder		  105
+		  ZOrder		  121
 		  SrcBlock		  "Kp_Kd_CoM"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  9
 		}
 		Line {
-		  ZOrder		  106
+		  ZOrder		  122
 		  SrcBlock		  "Kp_Kd_LFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  10
 		}
 		Line {
-		  ZOrder		  107
+		  ZOrder		  123
 		  SrcBlock		  "Kp_Kd_RFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  11
 		}
 		Line {
-		  ZOrder		  108
+		  ZOrder		  124
 		  SrcBlock		  "Kp_Kd_rot_task"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  12
 		}
 		Line {
-		  ZOrder		  109
+		  ZOrder		  125
 		  SrcBlock		  "feetInContact"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
@@ -5728,7 +5709,7 @@ Model {
 		}
 		Line {
 		  Name			  "acc_task_star"
-		  ZOrder		  110
+		  ZOrder		  126
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  2
@@ -5736,14 +5717,14 @@ Model {
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  111
+		  ZOrder		  127
 		  SrcBlock		  " Demux "
 		  SrcPort		  1
 		  DstBlock		  " Terminator "
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  112
+		  ZOrder		  128
 		  SrcBlock		  " SFunction "
 		  SrcPort		  1
 		  DstBlock		  " Demux "
@@ -5865,7 +5846,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "94"
+		    SIDHighWatermark	    "97"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "vel_CoM"
@@ -5940,56 +5921,48 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4288::93"
+		    SID			    "4288::96"
 		    Ports		    [1, 1]
 		    Position		    [270, 280, 320, 320]
-		    ZOrder		    84
+		    ZOrder		    87
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4288::92"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 4"
+		    SID			    "4288::95"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 4"
 		    Ports		    [8, 5]
 		    Position		    [180, 100, 230, 280]
-		    ZOrder		    83
+		    ZOrder		    86
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[8 5]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "pos_vel_CoM"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "pose_vel_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "pose_vel_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    5
 		    Name		    "orient_vel_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4288::94"
+		    SID			    "4288::97"
 		    Position		    [460, 291, 480, 309]
-		    ZOrder		    85
+		    ZOrder		    88
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -6027,56 +6000,56 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    85
+		    ZOrder		    99
 		    SrcBlock		    "vel_CoM"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    86
+		    ZOrder		    100
 		    SrcBlock		    "vel_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    87
+		    ZOrder		    101
 		    SrcBlock		    "vel_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    88
+		    ZOrder		    102
 		    SrcBlock		    "vel_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    89
+		    ZOrder		    103
 		    SrcBlock		    "w_H_CoM"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    90
+		    ZOrder		    104
 		    SrcBlock		    "w_H_l_sole"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    6
 		    }
 		    Line {
-		    ZOrder		    91
+		    ZOrder		    105
 		    SrcBlock		    "w_H_r_sole"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    7
 		    }
 		    Line {
-		    ZOrder		    92
+		    ZOrder		    106
 		    SrcBlock		    "w_H_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -6084,7 +6057,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pos_vel_CoM"
-		    ZOrder		    93
+		    ZOrder		    107
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -6093,7 +6066,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pose_vel_LFoot"
-		    ZOrder		    94
+		    ZOrder		    108
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -6102,7 +6075,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pose_vel_RFoot"
-		    ZOrder		    95
+		    ZOrder		    109
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -6111,7 +6084,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "orient_vel_rot_task"
-		    ZOrder		    96
+		    ZOrder		    110
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    5
@@ -6119,14 +6092,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    97
+		    ZOrder		    111
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    98
+		    ZOrder		    112
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    Points		    [20, 0]
@@ -7316,7 +7289,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "64"
+		    SIDHighWatermark	    "67"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "s"
@@ -7391,56 +7364,48 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4342::63"
+		    SID			    "4342::66"
 		    Ports		    [1, 1]
 		    Position		    [270, 280, 320, 320]
-		    ZOrder		    54
+		    ZOrder		    57
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4342::62"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 5"
+		    SID			    "4342::65"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 5"
 		    Ports		    [8, 5]
 		    Position		    [180, 100, 230, 280]
-		    ZOrder		    53
+		    ZOrder		    56
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[8 5]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "Hessian"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "gradient"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "ConstraintMatrix"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    5
 		    Name		    "biasVectorConstraint"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4342::64"
+		    SID			    "4342::67"
 		    Position		    [460, 291, 480, 309]
-		    ZOrder		    55
+		    ZOrder		    58
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -7478,56 +7443,56 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    85
+		    ZOrder		    99
 		    SrcBlock		    "s"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    86
+		    ZOrder		    100
 		    SrcBlock		    "nu"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    87
+		    ZOrder		    101
 		    SrcBlock		    "s_sDot_sDDot_ref"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    88
+		    ZOrder		    102
 		    SrcBlock		    "impedances"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    89
+		    ZOrder		    103
 		    SrcBlock		    "dampings"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    90
+		    ZOrder		    104
 		    SrcBlock		    "J"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    6
 		    }
 		    Line {
-		    ZOrder		    91
+		    ZOrder		    105
 		    SrcBlock		    "JDot_nu"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    7
 		    }
 		    Line {
-		    ZOrder		    92
+		    ZOrder		    106
 		    SrcBlock		    "acc_task_star"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -7535,7 +7500,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "Hessian"
-		    ZOrder		    93
+		    ZOrder		    107
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -7544,7 +7509,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "gradient"
-		    ZOrder		    94
+		    ZOrder		    108
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -7553,7 +7518,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "ConstraintMatrix"
-		    ZOrder		    95
+		    ZOrder		    109
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -7562,7 +7527,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "biasVectorConstraint"
-		    ZOrder		    96
+		    ZOrder		    110
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    5
@@ -7570,14 +7535,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    97
+		    ZOrder		    111
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    98
+		    ZOrder		    112
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    Points		    [20, 0]
@@ -7808,7 +7773,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "65"
+		    SIDHighWatermark	    "68"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "pose_b"
@@ -7829,38 +7794,36 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4356::64"
+		    SID			    "4356::67"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    50
+		    ZOrder		    53
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4356::63"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 16"
+		    SID			    "4356::66"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 16"
 		    Ports		    [2, 2]
 		    Position		    [180, 100, 230, 160]
-		    ZOrder		    49
+		    ZOrder		    52
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[2 2]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "pose_bDot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4356::65"
+		    SID			    "4356::68"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    51
+		    ZOrder		    54
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -7871,7 +7834,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    36
+		    ZOrder		    41
 		    SrcBlock		    "pose_b"
 		    SrcPort		    1
 		    Points		    [120, 0]
@@ -7879,7 +7842,7 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    37
+		    ZOrder		    42
 		    SrcBlock		    "nu_b"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -7887,7 +7850,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pose_bDot"
-		    ZOrder		    38
+		    ZOrder		    43
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -7895,14 +7858,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    39
+		    ZOrder		    44
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    40
+		    ZOrder		    45
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -8058,7 +8021,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "64"
+		    SIDHighWatermark	    "67"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "w_H_b_0"
@@ -8070,38 +8033,36 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4363::63"
+		    SID			    "4363::66"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    49
+		    ZOrder		    52
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4363::62"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 18"
+		    SID			    "4363::65"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 18"
 		    Ports		    [1, 2]
 		    Position		    [180, 100, 230, 160]
-		    ZOrder		    48
+		    ZOrder		    51
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[1 2]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "pose_b_0"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4363::64"
+		    SID			    "4363::67"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    50
+		    ZOrder		    53
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -8112,7 +8073,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    25
+		    ZOrder		    29
 		    SrcBlock		    "w_H_b_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -8120,7 +8081,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pose_b_0"
-		    ZOrder		    26
+		    ZOrder		    30
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -8128,14 +8089,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    27
+		    ZOrder		    31
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    28
+		    ZOrder		    32
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -8172,7 +8133,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "64"
+		    SIDHighWatermark	    "67"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "pose_b"
@@ -8184,38 +8145,36 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4364::63"
+		    SID			    "4364::66"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    49
+		    ZOrder		    52
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4364::62"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 15"
+		    SID			    "4364::65"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 15"
 		    Ports		    [1, 2]
 		    Position		    [180, 100, 230, 160]
-		    ZOrder		    48
+		    ZOrder		    51
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[1 2]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "w_H_b"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4364::64"
+		    SID			    "4364::67"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    50
+		    ZOrder		    53
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -8226,7 +8185,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    25
+		    ZOrder		    29
 		    SrcBlock		    "pose_b"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -8234,7 +8193,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "w_H_b"
-		    ZOrder		    26
+		    ZOrder		    30
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -8242,14 +8201,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    27
+		    ZOrder		    31
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    28
+		    ZOrder		    32
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -8878,32 +8837,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -8924,32 +8873,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -8970,32 +8909,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -9016,32 +8945,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -9062,32 +8981,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -9108,32 +9017,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -9154,32 +9053,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -9281,7 +9170,7 @@ Model {
 		  "rker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on'"
 		  ")}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayou"
 		  "tDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY"
-		  "'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[66 106 1377 "
+		  "'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 106 1377 "
 		  "825])"
 		  NumInputPorts		  "1"
 		}
@@ -9434,7 +9323,7 @@ Model {
 		  "tyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames"
 		  "',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Nav"
 		  "igation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Versi"
-		  "on','2016b')),'Version','2017b','Location',[66 109 1377 828])"
+		  "on','2016b')),'Version','2017a','Location',[66 109 1377 828])"
 		  NumInputPorts		  "1"
 		}
 		Block {
@@ -9526,7 +9415,7 @@ Model {
 		  "uct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{"
 		  "}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),extmgr.Confi"
 		  "guration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools',"
-		  "'Measurements',true,'Version','2016b')),'Version','2017b','Location',[363 356 1674 1075])"
+		  "'Measurements',true,'Version','2016b')),'Version','2017a','Location',[363 356 1674 1075])"
 		  NumInputPorts		  "5"
 		}
 		Block {
@@ -9618,7 +9507,7 @@ Model {
 		  "n'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNa"
 		  "mes',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),extmg"
 		  "r.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('"
-		  "Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[66 106 1377 825])"
+		  "Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 106 1377 825])"
 		  NumInputPorts		  "5"
 		}
 		Block {
@@ -9708,7 +9597,7 @@ Model {
 		  "le','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedCha"
 		  "nnelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1])"
 		  ",extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurement"
-		  "s',true,'Version','2017b')),'Version','2017b','Location',[66 78 1367 767])"
+		  "s',true,'Version','2017b')),'Version','2017a','Location',[66 78 1367 767])"
 		  NumInputPorts		  "5"
 		}
 		Block {
@@ -9798,7 +9687,7 @@ Model {
 		  "','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDe"
 		  "finedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions"
 		  "',[6 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false),extmgr.Configuration('Tools','Mea"
-		  "surements',true,'Version','2017b')),'Version','2017b','Location',[66 106 1367 795])"
+		  "surements',true,'Version','2017b')),'Version','2017a','Location',[66 106 1367 795])"
 		  NumInputPorts		  "5"
 		}
 		Block {
@@ -9890,7 +9779,7 @@ Model {
 		  "e','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChan"
 		  "nelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),"
 		  "extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configurat"
-		  "ion('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[351 265 1632 866])"
+		  "ion('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[351 265 1632 866])"
 		  NumInputPorts		  "5"
 		}
 		Block {
@@ -9982,7 +9871,7 @@ Model {
 		  "truct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',"
 		  "{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),extmgr.Con"
 		  "figuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools"
-		  "','Measurements',true,'Version','2016b')),'Version','2017b','Location',[515 467 1806 1126])"
+		  "','Measurements',true,'Version','2016b')),'Version','2017a','Location',[515 467 1806 1126])"
 		  NumInputPorts		  "5"
 		}
 		Block {
@@ -10072,7 +9961,7 @@ Model {
 		  "'Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefi"
 		  "nedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',"
 		  "[6 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false),extmgr.Configuration('Tools','Measu"
-		  "rements',true,'Version','2017b')),'Version','2017b','Location',[66 78 1367 767])"
+		  "rements',true,'Version','2017b')),'Version','2017a','Location',[66 78 1367 767])"
 		  NumInputPorts		  "5"
 		}
 		Line {
@@ -11245,7 +11134,7 @@ Model {
 		TiledPageScale		1
 		ShowPageBoundaries	off
 		ZoomFactor		"100"
-		SIDHighWatermark	"79"
+		SIDHighWatermark	"82"
 		Block {
 		  BlockType		  Inport
 		  Name			  "pos_vel_acc_CoM_des"
@@ -11365,39 +11254,37 @@ Model {
 		Block {
 		  BlockType		  Demux
 		  Name			  " Demux "
-		  SID			  "4438::78"
+		  SID			  "4438::81"
 		  Ports			  [1, 1]
 		  Position		  [270, 230, 320, 270]
-		  ZOrder		  68
+		  ZOrder		  71
 		  Outputs		  "1"
 		}
 		Block {
 		  BlockType		  S-Function
 		  Name			  " SFunction "
-		  SID			  "4438::77"
-		  Tag			  "Stateflow S-Function torqueWalkingMPC 6"
+		  SID			  "4438::80"
+		  Tag			  "Stateflow S-Function torqueWalkingMPC_2016b 6"
 		  Ports			  [13, 2]
 		  Position		  [180, 90, 230, 370]
-		  ZOrder		  67
+		  ZOrder		  70
 		  FunctionName		  "sf_sfun"
 		  Parameters		  "Sat"
 		  PortCounts		  "[13 2]"
 		  SFunctionDeploymentMode off
-		  EnableBusSupport	  on
+		  EnableBusSupport	  off
 		  SFcnIsStateOwnerBlock	  off
 		  Port {
 		    PortNumber		    2
 		    Name		    "acc_task_star"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
 		  BlockType		  Terminator
 		  Name			  " Terminator "
-		  SID			  "4438::79"
+		  SID			  "4438::82"
 		  Position		  [460, 241, 480, 259]
-		  ZOrder		  69
+		  ZOrder		  72
 		}
 		Block {
 		  BlockType		  Outport
@@ -11408,91 +11295,91 @@ Model {
 		  IconDisplay		  "Port number"
 		}
 		Line {
-		  ZOrder		  97
+		  ZOrder		  113
 		  SrcBlock		  "pos_vel_acc_CoM_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  98
+		  ZOrder		  114
 		  SrcBlock		  "pose_vel_acc_LFoot_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  2
 		}
 		Line {
-		  ZOrder		  99
+		  ZOrder		  115
 		  SrcBlock		  "pose_vel_acc_RFoot_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  3
 		}
 		Line {
-		  ZOrder		  100
+		  ZOrder		  116
 		  SrcBlock		  "orient_vel_acc_rot_task_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  4
 		}
 		Line {
-		  ZOrder		  101
+		  ZOrder		  117
 		  SrcBlock		  "pos_vel_CoM"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  5
 		}
 		Line {
-		  ZOrder		  102
+		  ZOrder		  118
 		  SrcBlock		  "pose_vel_LFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  6
 		}
 		Line {
-		  ZOrder		  103
+		  ZOrder		  119
 		  SrcBlock		  "pose_vel_RFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  7
 		}
 		Line {
-		  ZOrder		  104
+		  ZOrder		  120
 		  SrcBlock		  "orient_vel_rot_task"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  8
 		}
 		Line {
-		  ZOrder		  105
+		  ZOrder		  121
 		  SrcBlock		  "Kp_Kd_CoM"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  9
 		}
 		Line {
-		  ZOrder		  106
+		  ZOrder		  122
 		  SrcBlock		  "Kp_Kd_LFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  10
 		}
 		Line {
-		  ZOrder		  107
+		  ZOrder		  123
 		  SrcBlock		  "Kp_Kd_RFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  11
 		}
 		Line {
-		  ZOrder		  108
+		  ZOrder		  124
 		  SrcBlock		  "Kp_Kd_rot_task"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  12
 		}
 		Line {
-		  ZOrder		  109
+		  ZOrder		  125
 		  SrcBlock		  "feetInContact"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
@@ -11500,7 +11387,7 @@ Model {
 		}
 		Line {
 		  Name			  "acc_task_star"
-		  ZOrder		  110
+		  ZOrder		  126
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  2
@@ -11508,14 +11395,14 @@ Model {
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  111
+		  ZOrder		  127
 		  SrcBlock		  " Demux "
 		  SrcPort		  1
 		  DstBlock		  " Terminator "
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  112
+		  ZOrder		  128
 		  SrcBlock		  " SFunction "
 		  SrcPort		  1
 		  DstBlock		  " Demux "
@@ -11637,7 +11524,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "94"
+		    SIDHighWatermark	    "97"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "vel_CoM"
@@ -11712,56 +11599,48 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4447::93"
+		    SID			    "4447::96"
 		    Ports		    [1, 1]
 		    Position		    [270, 280, 320, 320]
-		    ZOrder		    84
+		    ZOrder		    87
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4447::92"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 7"
+		    SID			    "4447::95"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 7"
 		    Ports		    [8, 5]
 		    Position		    [180, 100, 230, 280]
-		    ZOrder		    83
+		    ZOrder		    86
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[8 5]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "pos_vel_CoM"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "pose_vel_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "pose_vel_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    5
 		    Name		    "orient_vel_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4447::94"
+		    SID			    "4447::97"
 		    Position		    [460, 291, 480, 309]
-		    ZOrder		    85
+		    ZOrder		    88
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -11799,56 +11678,56 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    85
+		    ZOrder		    99
 		    SrcBlock		    "vel_CoM"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    86
+		    ZOrder		    100
 		    SrcBlock		    "vel_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    87
+		    ZOrder		    101
 		    SrcBlock		    "vel_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    88
+		    ZOrder		    102
 		    SrcBlock		    "vel_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    89
+		    ZOrder		    103
 		    SrcBlock		    "w_H_CoM"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    90
+		    ZOrder		    104
 		    SrcBlock		    "w_H_l_sole"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    6
 		    }
 		    Line {
-		    ZOrder		    91
+		    ZOrder		    105
 		    SrcBlock		    "w_H_r_sole"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    7
 		    }
 		    Line {
-		    ZOrder		    92
+		    ZOrder		    106
 		    SrcBlock		    "w_H_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -11856,7 +11735,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pos_vel_CoM"
-		    ZOrder		    93
+		    ZOrder		    107
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -11865,7 +11744,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pose_vel_LFoot"
-		    ZOrder		    94
+		    ZOrder		    108
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -11874,7 +11753,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pose_vel_RFoot"
-		    ZOrder		    95
+		    ZOrder		    109
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -11883,7 +11762,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "orient_vel_rot_task"
-		    ZOrder		    96
+		    ZOrder		    110
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    5
@@ -11891,14 +11770,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    97
+		    ZOrder		    111
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    98
+		    ZOrder		    112
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    Points		    [20, 0]
@@ -13232,7 +13111,7 @@ Model {
       Variant		      off
       System {
 	Name			"Robot State and References"
-	Location		[65, 24, 1920, 1080]
+	Location		[61, 35, 1916, 1091]
 	Open			off
 	ModelBrowserVisibility	off
 	ModelBrowserWidth	200
@@ -13244,7 +13123,7 @@ Model {
 	TiledPaperMargins	[0.500000, 0.500000, 0.500000, 0.500000]
 	TiledPageScale		1
 	ShowPageBoundaries	off
-	ZoomFactor		"170"
+	ZoomFactor		"100"
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "Gain Scheduling"
@@ -13317,7 +13196,7 @@ Model {
 		TiledPageScale		1
 		ShowPageBoundaries	off
 		ZoomFactor		"100"
-		SIDHighWatermark	"72"
+		SIDHighWatermark	"75"
 		Block {
 		  BlockType		  Inport
 		  Name			  "state"
@@ -13329,99 +13208,77 @@ Model {
 		Block {
 		  BlockType		  Demux
 		  Name			  " Demux "
-		  SID			  "4534::71"
+		  SID			  "4534::74"
 		  Ports			  [1, 1]
 		  Position		  [270, 530, 320, 570]
-		  ZOrder		  61
+		  ZOrder		  64
 		  Outputs		  "1"
 		}
 		Block {
 		  BlockType		  S-Function
 		  Name			  " SFunction "
-		  SID			  "4534::70"
-		  Tag			  "Stateflow S-Function torqueWalkingMPC 8"
+		  SID			  "4534::73"
+		  Tag			  "Stateflow S-Function torqueWalkingMPC_2016b 8"
 		  Ports			  [1, 12]
 		  Position		  [180, 95, 230, 355]
-		  ZOrder		  60
+		  ZOrder		  63
 		  FunctionName		  "sf_sfun"
 		  Parameters		  "Config,Gains"
 		  PortCounts		  "[1 12]"
 		  SFunctionDeploymentMode off
-		  EnableBusSupport	  on
+		  EnableBusSupport	  off
 		  SFcnIsStateOwnerBlock	  off
 		  Port {
 		    PortNumber		    2
 		    Name		    "Kp_CoM"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "Kd_CoM"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "Kp_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "Kd_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    6
 		    Name		    "Kp_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    7
 		    Name		    "Kd_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    8
 		    Name		    "Kp_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    9
 		    Name		    "Kd_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    10
 		    Name		    "impedances"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    11
 		    Name		    "dampings"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    12
 		    Name		    "smoothingTimeGains"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
 		  BlockType		  Terminator
 		  Name			  " Terminator "
-		  SID			  "4534::72"
+		  SID			  "4534::75"
 		  Position		  [460, 541, 480, 559]
-		  ZOrder		  62
+		  ZOrder		  65
 		}
 		Block {
 		  BlockType		  Outport
@@ -13522,7 +13379,7 @@ Model {
 		  IconDisplay		  "Port number"
 		}
 		Line {
-		  ZOrder		  127
+		  ZOrder		  141
 		  SrcBlock		  "state"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
@@ -13530,7 +13387,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kp_CoM"
-		  ZOrder		  128
+		  ZOrder		  142
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  2
@@ -13539,7 +13396,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kd_CoM"
-		  ZOrder		  129
+		  ZOrder		  143
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  3
@@ -13548,7 +13405,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kp_LFoot"
-		  ZOrder		  130
+		  ZOrder		  144
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  4
@@ -13557,7 +13414,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kd_LFoot"
-		  ZOrder		  131
+		  ZOrder		  145
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  5
@@ -13566,7 +13423,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kp_RFoot"
-		  ZOrder		  132
+		  ZOrder		  146
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  6
@@ -13575,7 +13432,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kd_RFoot"
-		  ZOrder		  133
+		  ZOrder		  147
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  7
@@ -13584,7 +13441,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kp_rot_task"
-		  ZOrder		  134
+		  ZOrder		  148
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  8
@@ -13593,7 +13450,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kd_rot_task"
-		  ZOrder		  135
+		  ZOrder		  149
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  9
@@ -13602,7 +13459,7 @@ Model {
 		}
 		Line {
 		  Name			  "impedances"
-		  ZOrder		  136
+		  ZOrder		  150
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  10
@@ -13611,7 +13468,7 @@ Model {
 		}
 		Line {
 		  Name			  "dampings"
-		  ZOrder		  137
+		  ZOrder		  151
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  11
@@ -13620,7 +13477,7 @@ Model {
 		}
 		Line {
 		  Name			  "smoothingTimeGains"
-		  ZOrder		  138
+		  ZOrder		  152
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  12
@@ -13628,14 +13485,14 @@ Model {
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  139
+		  ZOrder		  153
 		  SrcBlock		  " Demux "
 		  SrcPort		  1
 		  DstBlock		  " Terminator "
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  140
+		  ZOrder		  154
 		  SrcBlock		  " SFunction "
 		  SrcPort		  1
 		  DstBlock		  " Demux "
@@ -14138,7 +13995,7 @@ Model {
 	  Variant		  off
 	  System {
 	    Name		    "Smooth References "
-	    Location		    [65, 24, 1920, 1080]
+	    Location		    [61, 35, 1916, 1091]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -14150,7 +14007,7 @@ Model {
 	    TiledPaperMargins	    [0.500000, 0.500000, 0.500000, 0.500000]
 	    TiledPageScale	    1
 	    ShowPageBoundaries	    off
-	    ZoomFactor		    "181"
+	    ZoomFactor		    "125"
 	    Block {
 	      BlockType		      Inport
 	      Name		      "state"
@@ -15350,7 +15207,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "80"
+		    SIDHighWatermark	    "83"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "w_R_LFoot_des"
@@ -15443,51 +15300,45 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4570::79"
+		    SID			    "4570::82"
 		    Ports		    [1, 1]
 		    Position		    [270, 245, 320, 285]
-		    ZOrder		    69
+		    ZOrder		    72
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4570::78"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 9"
+		    SID			    "4570::81"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 9"
 		    Ports		    [10, 4]
 		    Position		    [180, 100, 230, 320]
-		    ZOrder		    68
+		    ZOrder		    71
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Config"
 		    PortCounts		    "[10 4]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "omegaDot_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "omegaDot_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "omegaDot_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4570::80"
+		    SID			    "4570::83"
 		    Position		    [460, 256, 480, 274]
-		    ZOrder		    70
+		    ZOrder		    73
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -15516,70 +15367,70 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    120
+		    ZOrder		    135
 		    SrcBlock		    "w_R_LFoot_des"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    121
+		    ZOrder		    136
 		    SrcBlock		    "w_R_RFoot_des"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    122
+		    ZOrder		    137
 		    SrcBlock		    "w_R_rot_task_des"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    123
+		    ZOrder		    138
 		    SrcBlock		    "w_R_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    124
+		    ZOrder		    139
 		    SrcBlock		    "w_R_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    125
+		    ZOrder		    140
 		    SrcBlock		    "w_R_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    6
 		    }
 		    Line {
-		    ZOrder		    126
+		    ZOrder		    141
 		    SrcBlock		    "state"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    7
 		    }
 		    Line {
-		    ZOrder		    127
+		    ZOrder		    142
 		    SrcBlock		    "omega_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    8
 		    }
 		    Line {
-		    ZOrder		    128
+		    ZOrder		    143
 		    SrcBlock		    "omega_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    9
 		    }
 		    Line {
-		    ZOrder		    129
+		    ZOrder		    144
 		    SrcBlock		    "omega_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -15587,7 +15438,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "omegaDot_LFoot"
-		    ZOrder		    130
+		    ZOrder		    145
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -15596,7 +15447,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "omegaDot_RFoot"
-		    ZOrder		    131
+		    ZOrder		    146
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -15605,7 +15456,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "omegaDot_rot_task"
-		    ZOrder		    132
+		    ZOrder		    147
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -15613,14 +15464,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    133
+		    ZOrder		    148
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    134
+		    ZOrder		    149
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -16194,7 +16045,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "82"
+		    SIDHighWatermark	    "85"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "omega_LFoot"
@@ -16251,50 +16102,44 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4571::81"
+		    SID			    "4571::84"
 		    Ports		    [1, 1]
 		    Position		    [270, 245, 320, 285]
-		    ZOrder		    71
+		    ZOrder		    74
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4571::80"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 12"
+		    SID			    "4571::83"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 12"
 		    Ports		    [6, 4]
 		    Position		    [180, 102, 230, 243]
-		    ZOrder		    70
+		    ZOrder		    73
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[6 4]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "RDot_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "RDot_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "RDot_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4571::82"
+		    SID			    "4571::85"
 		    Position		    [460, 256, 480, 274]
-		    ZOrder		    72
+		    ZOrder		    75
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -16323,42 +16168,42 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    67
+		    ZOrder		    78
 		    SrcBlock		    "omega_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    68
+		    ZOrder		    79
 		    SrcBlock		    "omega_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    69
+		    ZOrder		    80
 		    SrcBlock		    "omega_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    70
+		    ZOrder		    81
 		    SrcBlock		    "w_R_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    71
+		    ZOrder		    82
 		    SrcBlock		    "w_R_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    72
+		    ZOrder		    83
 		    SrcBlock		    "w_R_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -16366,7 +16211,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "RDot_LFoot"
-		    ZOrder		    73
+		    ZOrder		    84
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -16375,7 +16220,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "RDot_RFoot"
-		    ZOrder		    74
+		    ZOrder		    85
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -16384,7 +16229,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "RDot_rot_task"
-		    ZOrder		    75
+		    ZOrder		    86
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -16392,14 +16237,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    76
+		    ZOrder		    87
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    77
+		    ZOrder		    88
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    Points		    [20, 0]
@@ -16887,13 +16732,13 @@ Model {
 	      Name		      "Smooth Reference Positions"
 	      SID		      "4624"
 	      Ports		      [5, 4]
-	      Position		      [-220, 281, -10, 419]
+	      Position		      [-220, 289, -10, 431]
 	      ZOrder		      867
 	      RequestExecContextInheritance off
 	      Variant		      off
 	      System {
 		Name			"Smooth Reference Positions"
-		Location		[65, 24, 1920, 1080]
+		Location		[61, 35, 1916, 1091]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -16905,7 +16750,7 @@ Model {
 		TiledPaperMargins	[0.500000, 0.500000, 0.500000, 0.500000]
 		TiledPageScale		1
 		ShowPageBoundaries	off
-		ZoomFactor		"202"
+		ZoomFactor		"125"
 		Block {
 		  BlockType		  Inport
 		  Name			  "pos_CoM_des"
@@ -16916,37 +16761,37 @@ Model {
 		}
 		Block {
 		  BlockType		  Inport
-		  Name			  "pos_LFoot_des"
-		  SID			  "4626"
-		  Position		  [150, 315, 180, 325]
-		  ZOrder		  757
+		  Name			  "state"
+		  SID			  "5312"
+		  Position		  [-135, 298, -105, 312]
+		  ZOrder		  766
 		  Port			  "2"
-		  IconDisplay		  "Port number"
-		}
-		Block {
-		  BlockType		  Inport
-		  Name			  "pos_RFoot_des"
-		  SID			  "4627"
-		  Position		  [150, 395, 180, 405]
-		  ZOrder		  758
-		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "s_des"
 		  SID			  "4628"
+		  Position		  [150, 395, 180, 405]
+		  ZOrder		  770
+		  Port			  "3"
+		  IconDisplay		  "Port number"
+		}
+		Block {
+		  BlockType		  Inport
+		  Name			  "pos_LFoot_des"
+		  SID			  "4626"
 		  Position		  [150, 235, 180, 245]
-		  ZOrder		  759
+		  ZOrder		  777
 		  Port			  "4"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
-		  Name			  "state"
-		  SID			  "5312"
-		  Position		  [-135, 298, -105, 312]
-		  ZOrder		  766
+		  Name			  "pos_RFoot_des"
+		  SID			  "4627"
+		  Position		  [150, 315, 180, 325]
+		  ZOrder		  778
 		  Port			  "5"
 		  IconDisplay		  "Port number"
 		}
@@ -16978,7 +16823,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "48"
+		    SIDHighWatermark	    "51"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "state"
@@ -16990,57 +16835,49 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "5315::47"
+		    SID			    "5315::50"
 		    Ports		    [1, 1]
 		    Position		    [270, 280, 320, 320]
-		    ZOrder		    38
+		    ZOrder		    41
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "5315::46"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 17"
+		    SID			    "5315::49"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 17"
 		    Ports		    [1, 5]
 		    Position		    [180, 100, 230, 220]
-		    ZOrder		    37
+		    ZOrder		    40
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Config"
 		    PortCounts		    "[1 5]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "smoothingTime_CoM"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "smoothingTime_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "smoothingTime_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    5
 		    Name		    "smoothingTime_joints"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "5315::48"
+		    SID			    "5315::51"
 		    Position		    [460, 291, 480, 309]
-		    ZOrder		    39
+		    ZOrder		    42
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -17078,7 +16915,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    145
+		    ZOrder		    152
 		    SrcBlock		    "state"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -17086,7 +16923,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "smoothingTime_CoM"
-		    ZOrder		    146
+		    ZOrder		    153
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -17096,7 +16933,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "smoothingTime_LFoot"
-		    ZOrder		    147
+		    ZOrder		    154
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -17105,7 +16942,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "smoothingTime_RFoot"
-		    ZOrder		    148
+		    ZOrder		    155
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -17114,7 +16951,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "smoothingTime_joints"
-		    ZOrder		    149
+		    ZOrder		    156
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    5
@@ -17122,14 +16959,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    150
+		    ZOrder		    157
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    151
+		    ZOrder		    158
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -17142,8 +16979,8 @@ Model {
 		  Name			  "Matrix\nConcatenate1"
 		  SID			  "4629"
 		  Ports			  [3, 1]
-		  Position		  [450, 222, 575, 278]
-		  ZOrder		  693
+		  Position		  [450, 382, 575, 438]
+		  ZOrder		  769
 		  NamePlacement		  "alternate"
 		  NumInputs		  "3"
 		  Mode			  "Multidimensional array"
@@ -17154,8 +16991,8 @@ Model {
 		  Name			  "Matrix\nConcatenate2"
 		  SID			  "4630"
 		  Ports			  [4, 1]
-		  Position		  [450, 383, 575, 457]
-		  ZOrder		  711
+		  Position		  [450, 303, 575, 377]
+		  ZOrder		  775
 		  NamePlacement		  "alternate"
 		  NumInputs		  "4"
 		  Mode			  "Multidimensional array"
@@ -17166,8 +17003,8 @@ Model {
 		  Name			  "Matrix\nConcatenate3"
 		  SID			  "4631"
 		  Ports			  [4, 1]
-		  Position		  [450, 301, 575, 379]
-		  ZOrder		  713
+		  Position		  [450, 221, 575, 299]
+		  ZOrder		  776
 		  NamePlacement		  "alternate"
 		  NumInputs		  "4"
 		  Mode			  "Multidimensional array"
@@ -17208,8 +17045,8 @@ Model {
 		  Name			  "Minimum Jerk Trajectory Generator1"
 		  SID			  "4634"
 		  Ports			  [2, 3]
-		  Position		  [235, 223, 390, 277]
-		  ZOrder		  692
+		  Position		  [235, 383, 390, 437]
+		  ZOrder		  768
 		  LibraryVersion	  "1.383"
 		  SourceBlock		  "WBToolboxLibrary/Utilities/Minimum Jerk Trajectory Generator"
 		  SourceType		  "Minimum Jerk Trajectory Generator"
@@ -17226,8 +17063,8 @@ Model {
 		  Name			  "Minimum Jerk Trajectory Generator2"
 		  SID			  "4635"
 		  Ports			  [2, 3]
-		  Position		  [235, 303, 390, 357]
-		  ZOrder		  696
+		  Position		  [235, 223, 390, 277]
+		  ZOrder		  772
 		  LibraryVersion	  "1.383"
 		  SourceBlock		  "WBToolboxLibrary/Utilities/Minimum Jerk Trajectory Generator"
 		  SourceType		  "Minimum Jerk Trajectory Generator"
@@ -17244,8 +17081,8 @@ Model {
 		  Name			  "Minimum Jerk Trajectory Generator3"
 		  SID			  "4636"
 		  Ports			  [2, 3]
-		  Position		  [235, 383, 390, 437]
-		  ZOrder		  697
+		  Position		  [235, 303, 390, 357]
+		  ZOrder		  773
 		  LibraryVersion	  "1.383"
 		  SourceBlock		  "WBToolboxLibrary/Utilities/Minimum Jerk Trajectory Generator"
 		  SourceType		  "Minimum Jerk Trajectory Generator"
@@ -17261,8 +17098,8 @@ Model {
 		  BlockType		  Constant
 		  Name			  "Settling time1"
 		  SID			  "4637"
-		  Position		  [285, 441, 345, 459]
-		  ZOrder		  710
+		  Position		  [285, 466, 345, 484]
+		  ZOrder		  774
 		  Value			  "zeros(3,2)"
 		}
 		Block {
@@ -17275,92 +17112,36 @@ Model {
 		}
 		Block {
 		  BlockType		  Outport
+		  Name			  "smooth_references_s"
+		  SID			  "4640"
+		  Position		  [675, 403, 705, 417]
+		  ZOrder		  771
+		  Port			  "2"
+		  IconDisplay		  "Port number"
+		}
+		Block {
+		  BlockType		  Outport
 		  Name			  "smooth_pos_vel_acc_LFoot"
 		  SID			  "4641"
-		  Position		  [675, 333, 705, 347]
-		  ZOrder		  764
-		  Port			  "2"
+		  Position		  [675, 253, 705, 267]
+		  ZOrder		  779
+		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "smooth_pos_vel_acc_RFoot"
 		  SID			  "4642"
-		  Position		  [675, 413, 705, 427]
-		  ZOrder		  765
-		  Port			  "3"
-		  IconDisplay		  "Port number"
-		}
-		Block {
-		  BlockType		  Outport
-		  Name			  "smooth_references_s"
-		  SID			  "4640"
-		  Position		  [675, 243, 705, 257]
-		  ZOrder		  761
+		  Position		  [675, 333, 705, 347]
+		  ZOrder		  780
 		  Port			  "4"
 		  IconDisplay		  "Port number"
-		}
-		Line {
-		  ZOrder		  1
-		  SrcBlock		  "Minimum Jerk Trajectory Generator2"
-		  SrcPort		  2
-		  DstBlock		  "Matrix\nConcatenate3"
-		  DstPort		  2
-		}
-		Line {
-		  ZOrder		  2
-		  SrcBlock		  "pos_LFoot_des"
-		  SrcPort		  1
-		  DstBlock		  "Minimum Jerk Trajectory Generator2"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  3
-		  SrcBlock		  "pos_RFoot_des"
-		  SrcPort		  1
-		  DstBlock		  "Minimum Jerk Trajectory Generator3"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  4
-		  SrcBlock		  "Minimum Jerk Trajectory Generator2"
-		  SrcPort		  3
-		  DstBlock		  "Matrix\nConcatenate3"
-		  DstPort		  3
-		}
-		Line {
-		  ZOrder		  5
-		  SrcBlock		  "Minimum Jerk Trajectory Generator2"
-		  SrcPort		  1
-		  DstBlock		  "Matrix\nConcatenate3"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  6
-		  SrcBlock		  "Minimum Jerk Trajectory Generator1"
-		  SrcPort		  3
-		  DstBlock		  "Matrix\nConcatenate1"
-		  DstPort		  3
-		}
-		Line {
-		  ZOrder		  7
-		  SrcBlock		  "Matrix\nConcatenate1"
-		  SrcPort		  1
-		  DstBlock		  "smooth_references_s"
-		  DstPort		  1
 		}
 		Line {
 		  ZOrder		  8
 		  SrcBlock		  "Matrix\nConcatenate4"
 		  SrcPort		  1
 		  DstBlock		  "smooth_references_CoM"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  9
-		  SrcBlock		  "Minimum Jerk Trajectory Generator1"
-		  SrcPort		  1
-		  DstBlock		  "Matrix\nConcatenate1"
 		  DstPort		  1
 		}
 		Line {
@@ -17385,76 +17166,10 @@ Model {
 		  DstPort		  2
 		}
 		Line {
-		  ZOrder		  13
-		  SrcBlock		  "Minimum Jerk Trajectory Generator1"
-		  SrcPort		  2
-		  DstBlock		  "Matrix\nConcatenate1"
-		  DstPort		  2
-		}
-		Line {
-		  ZOrder		  14
-		  SrcBlock		  "Minimum Jerk Trajectory Generator3"
-		  SrcPort		  3
-		  DstBlock		  "Matrix\nConcatenate2"
-		  DstPort		  3
-		}
-		Line {
-		  ZOrder		  15
-		  SrcBlock		  "Matrix\nConcatenate3"
-		  SrcPort		  1
-		  DstBlock		  "smooth_pos_vel_acc_LFoot"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  16
-		  SrcBlock		  "Matrix\nConcatenate2"
-		  SrcPort		  1
-		  DstBlock		  "smooth_pos_vel_acc_RFoot"
-		  DstPort		  1
-		}
-		Line {
 		  ZOrder		  17
 		  SrcBlock		  "Minimum Jerk Trajectory Generator"
 		  SrcPort		  1
 		  DstBlock		  "Matrix\nConcatenate4"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  18
-		  SrcBlock		  "Minimum Jerk Trajectory Generator3"
-		  SrcPort		  2
-		  DstBlock		  "Matrix\nConcatenate2"
-		  DstPort		  2
-		}
-		Line {
-		  ZOrder		  19
-		  SrcBlock		  "s_des"
-		  SrcPort		  1
-		  DstBlock		  "Minimum Jerk Trajectory Generator1"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  20
-		  SrcBlock		  "Settling time1"
-		  SrcPort		  1
-		  Points		  [63, 0]
-		  Branch {
-		    ZOrder		    21
-		    DstBlock		    "Matrix\nConcatenate2"
-		    DstPort		    4
-		  }
-		  Branch {
-		    ZOrder		    22
-		    Points		    [0, -80]
-		    DstBlock		    "Matrix\nConcatenate3"
-		    DstPort		    4
-		  }
-		}
-		Line {
-		  ZOrder		  30
-		  SrcBlock		  "Minimum Jerk Trajectory Generator3"
-		  SrcPort		  1
-		  DstBlock		  "Matrix\nConcatenate2"
 		  DstPort		  1
 		}
 		Line {
@@ -17472,25 +17187,147 @@ Model {
 		  DstPort		  2
 		}
 		Line {
-		  ZOrder		  33
-		  SrcBlock		  "Configure Settling Times"
+		  ZOrder		  48
+		  SrcBlock		  "Minimum Jerk Trajectory Generator1"
+		  SrcPort		  3
+		  DstBlock		  "Matrix\nConcatenate1"
+		  DstPort		  3
+		}
+		Line {
+		  ZOrder		  49
+		  SrcBlock		  "Minimum Jerk Trajectory Generator1"
 		  SrcPort		  2
+		  DstBlock		  "Matrix\nConcatenate1"
+		  DstPort		  2
+		}
+		Line {
+		  ZOrder		  71
+		  SrcBlock		  "Configure Settling Times"
+		  SrcPort		  4
 		  DstBlock		  "Minimum Jerk Trajectory Generator1"
 		  DstPort		  2
 		}
 		Line {
-		  ZOrder		  34
-		  SrcBlock		  "Configure Settling Times"
+		  ZOrder		  51
+		  SrcBlock		  "Minimum Jerk Trajectory Generator1"
+		  SrcPort		  1
+		  DstBlock		  "Matrix\nConcatenate1"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  52
+		  SrcBlock		  "s_des"
+		  SrcPort		  1
+		  DstBlock		  "Minimum Jerk Trajectory Generator1"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  53
+		  SrcBlock		  "Matrix\nConcatenate1"
+		  SrcPort		  1
+		  DstBlock		  "smooth_references_s"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  54
+		  SrcBlock		  "pos_LFoot_des"
+		  SrcPort		  1
+		  DstBlock		  "Minimum Jerk Trajectory Generator2"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  55
+		  SrcBlock		  "Minimum Jerk Trajectory Generator2"
+		  SrcPort		  2
+		  DstBlock		  "Matrix\nConcatenate3"
+		  DstPort		  2
+		}
+		Line {
+		  ZOrder		  56
+		  SrcBlock		  "Minimum Jerk Trajectory Generator2"
+		  SrcPort		  1
+		  DstBlock		  "Matrix\nConcatenate3"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  57
+		  SrcBlock		  "Minimum Jerk Trajectory Generator3"
 		  SrcPort		  3
+		  DstBlock		  "Matrix\nConcatenate2"
+		  DstPort		  3
+		}
+		Line {
+		  ZOrder		  58
+		  SrcBlock		  "Minimum Jerk Trajectory Generator2"
+		  SrcPort		  3
+		  DstBlock		  "Matrix\nConcatenate3"
+		  DstPort		  3
+		}
+		Line {
+		  ZOrder		  69
+		  SrcBlock		  "Configure Settling Times"
+		  SrcPort		  2
 		  DstBlock		  "Minimum Jerk Trajectory Generator2"
 		  DstPort		  2
 		}
 		Line {
-		  ZOrder		  35
+		  ZOrder		  60
+		  SrcBlock		  "Minimum Jerk Trajectory Generator3"
+		  SrcPort		  1
+		  DstBlock		  "Matrix\nConcatenate2"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  61
+		  SrcBlock		  "pos_RFoot_des"
+		  SrcPort		  1
+		  DstBlock		  "Minimum Jerk Trajectory Generator3"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  62
+		  SrcBlock		  "Matrix\nConcatenate3"
+		  SrcPort		  1
+		  DstBlock		  "smooth_pos_vel_acc_LFoot"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  63
+		  SrcBlock		  "Matrix\nConcatenate2"
+		  SrcPort		  1
+		  DstBlock		  "smooth_pos_vel_acc_RFoot"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  70
 		  SrcBlock		  "Configure Settling Times"
-		  SrcPort		  4
+		  SrcPort		  3
 		  DstBlock		  "Minimum Jerk Trajectory Generator3"
 		  DstPort		  2
+		}
+		Line {
+		  ZOrder		  65
+		  SrcBlock		  "Minimum Jerk Trajectory Generator3"
+		  SrcPort		  2
+		  DstBlock		  "Matrix\nConcatenate2"
+		  DstPort		  2
+		}
+		Line {
+		  ZOrder		  68
+		  SrcBlock		  "Settling time1"
+		  SrcPort		  1
+		  Points		  [63, 0; 0, -105]
+		  Branch {
+		    ZOrder		    67
+		    DstBlock		    "Matrix\nConcatenate2"
+		    DstPort		    4
+		  }
+		  Branch {
+		    ZOrder		    66
+		    Points		    [0, -80]
+		    DstBlock		    "Matrix\nConcatenate3"
+		    DstPort		    4
+		  }
 		}
 	      }
 	    }
@@ -17592,8 +17429,7 @@ Model {
 	      ZOrder		      96
 	      SrcBlock		      "Selector2"
 	      SrcPort		      1
-	      DstBlock		      "Smooth Reference Positions"
-	      DstPort		      2
+	      Points		      [55, 0]
 	    }
 	    Line {
 	      ZOrder		      97
@@ -17625,8 +17461,7 @@ Model {
 	      ZOrder		      98
 	      SrcBlock		      "Selector6"
 	      SrcPort		      1
-	      DstBlock		      "Smooth Reference Positions"
-	      DstPort		      3
+	      Points		      [25, 0; 0, 5; 30, 0]
 	    }
 	    Line {
 	      ZOrder		      99
@@ -17649,8 +17484,7 @@ Model {
 	      ZOrder		      100
 	      SrcBlock		      "Selector7"
 	      SrcPort		      1
-	      DstBlock		      "Smooth Reference Positions"
-	      DstPort		      4
+	      Points		      [55, 0]
 	    }
 	    Line {
 	      ZOrder		      101
@@ -17694,6 +17528,7 @@ Model {
 	      ZOrder		      142
 	      SrcBlock		      "Smooth Reference Positions"
 	      SrcPort		      1
+	      Points		      [25, 0; 0, -10]
 	      DstBlock		      "Choose Smoothed or Direct References"
 	      DstPort		      1
 	    }
@@ -17760,9 +17595,9 @@ Model {
 	      Points		      [218, 0]
 	      Branch {
 		ZOrder			190
-		Points			[0, -285]
+		Points			[0, -355]
 		DstBlock		"Smooth Reference Positions"
-		DstPort			5
+		DstPort			2
 	      }
 	      Branch {
 		ZOrder			189
@@ -17772,22 +17607,19 @@ Model {
 	    }
 	    Line {
 	      ZOrder		      191
-	      SrcBlock		      "Smooth Reference Positions"
-	      SrcPort		      2
+	      Points		      [-10, 340; 30, 0; 0, -5]
 	      DstBlock		      "Choose Smoothed or Direct References"
 	      DstPort		      2
 	    }
 	    Line {
 	      ZOrder		      192
-	      SrcBlock		      "Smooth Reference Positions"
-	      SrcPort		      3
+	      Points		      [-10, 375; 30, 0; 0, -5]
 	      DstBlock		      "Choose Smoothed or Direct References"
 	      DstPort		      3
 	    }
 	    Line {
 	      ZOrder		      193
-	      SrcBlock		      "Smooth Reference Positions"
-	      SrcPort		      4
+	      Points		      [-10, 405]
 	      DstBlock		      "Choose Smoothed or Direct References"
 	      DstPort		      4
 	    }
@@ -18065,8 +17897,6 @@ Model {
 		    Port {
 		    PortNumber		    1
 		    Name		    "imu_H_link"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
@@ -18085,8 +17915,6 @@ Model {
 		    Port {
 		    PortNumber		    1
 		    Name		    "link_H_root"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
@@ -18157,7 +17985,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "3737"
+		    SIDHighWatermark	    "3740"
 		    SIDPrevWatermark	    "9"
 		    Block {
 		    BlockType		    Inport
@@ -18215,39 +18043,37 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4716::3736"
+		    SID			    "4716::3739"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    136
+		    ZOrder		    139
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4716::3735"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 11"
+		    SID			    "4716::3738"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 11"
 		    Ports		    [6, 2]
 		    Position		    [180, 102, 230, 243]
-		    ZOrder		    135
+		    ZOrder		    138
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Config"
 		    PortCounts		    "[6 2]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "w_H_b"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4716::3737"
+		    SID			    "4716::3740"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    137
+		    ZOrder		    140
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -18258,42 +18084,42 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    55
+		    ZOrder		    64
 		    SrcBlock		    "imu_H_link"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    56
+		    ZOrder		    65
 		    SrcBlock		    "imu_H_link_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    57
+		    ZOrder		    66
 		    SrcBlock		    "link_H_base"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    58
+		    ZOrder		    67
 		    SrcBlock		    "inertial_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    59
+		    ZOrder		    68
 		    SrcBlock		    "inertial"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    60
+		    ZOrder		    69
 		    SrcBlock		    "neck_pos"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -18301,7 +18127,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "w_H_b"
-		    ZOrder		    61
+		    ZOrder		    70
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -18309,14 +18135,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    62
+		    ZOrder		    71
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    63
+		    ZOrder		    72
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -18421,8 +18247,6 @@ Model {
 		    Port {
 		    PortNumber		    1
 		    Name		    "neck pos"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
@@ -18807,8 +18631,6 @@ Model {
 		    Port {
 		    PortNumber		    1
 		    Name		    "imu_H_link"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
@@ -18827,8 +18649,6 @@ Model {
 		    Port {
 		    PortNumber		    1
 		    Name		    "link_H_root"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
@@ -18899,7 +18719,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "3737"
+		    SIDHighWatermark	    "3740"
 		    SIDPrevWatermark	    "9"
 		    Block {
 		    BlockType		    Inport
@@ -18957,39 +18777,37 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "5431::3736"
+		    SID			    "5431::3739"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    136
+		    ZOrder		    139
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "5431::3735"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 13"
+		    SID			    "5431::3738"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 13"
 		    Ports		    [6, 2]
 		    Position		    [180, 102, 230, 243]
-		    ZOrder		    135
+		    ZOrder		    138
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Config"
 		    PortCounts		    "[6 2]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "w_H_b"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "5431::3737"
+		    SID			    "5431::3740"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    137
+		    ZOrder		    140
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -19000,42 +18818,42 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    55
+		    ZOrder		    64
 		    SrcBlock		    "imu_H_link"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    56
+		    ZOrder		    65
 		    SrcBlock		    "imu_H_link_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    57
+		    ZOrder		    66
 		    SrcBlock		    "link_H_base"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    58
+		    ZOrder		    67
 		    SrcBlock		    "inertial_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    59
+		    ZOrder		    68
 		    SrcBlock		    "inertial"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    60
+		    ZOrder		    69
 		    SrcBlock		    "neck_pos"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -19043,7 +18861,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "w_H_b"
-		    ZOrder		    61
+		    ZOrder		    70
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -19051,14 +18869,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    62
+		    ZOrder		    71
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    63
+		    ZOrder		    72
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -19163,8 +18981,6 @@ Model {
 		    Port {
 		    PortNumber		    1
 		    Name		    "neck pos"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
@@ -19723,7 +19539,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "3735"
+		    SIDHighWatermark	    "3738"
 		    SIDPrevWatermark	    "9"
 		    Block {
 		    BlockType		    Inport
@@ -19736,38 +19552,36 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "5219::3734"
+		    SID			    "5219::3737"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    133
+		    ZOrder		    136
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "5219::3733"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 25"
+		    SID			    "5219::3736"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 25"
 		    Ports		    [1, 2]
 		    Position		    [180, 100, 230, 160]
-		    ZOrder		    132
+		    ZOrder		    135
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[1 2]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "w_walking_H_link"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "5219::3735"
+		    SID			    "5219::3738"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    134
+		    ZOrder		    137
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -19778,7 +19592,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    25
+		    ZOrder		    29
 		    SrcBlock		    "qt_link"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -19786,7 +19600,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "w_walking_H_link"
-		    ZOrder		    26
+		    ZOrder		    30
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -19794,14 +19608,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    27
+		    ZOrder		    31
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    28
+		    ZOrder		    32
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -19838,7 +19652,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "3735"
+		    SIDHighWatermark	    "3738"
 		    SIDPrevWatermark	    "9"
 		    Block {
 		    BlockType		    Inport
@@ -19851,38 +19665,36 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "5507::3734"
+		    SID			    "5507::3737"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    133
+		    ZOrder		    136
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "5507::3733"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 19"
+		    SID			    "5507::3736"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 19"
 		    Ports		    [1, 2]
 		    Position		    [180, 100, 230, 160]
-		    ZOrder		    132
+		    ZOrder		    135
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[1 2]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "w_walking_H_link"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "5507::3735"
+		    SID			    "5507::3738"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    134
+		    ZOrder		    137
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -19893,7 +19705,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    25
+		    ZOrder		    29
 		    SrcBlock		    "qt_link"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -19901,7 +19713,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "w_walking_H_link"
-		    ZOrder		    26
+		    ZOrder		    30
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -19909,14 +19721,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    27
+		    ZOrder		    31
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    28
+		    ZOrder		    32
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -20330,7 +20142,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "3746"
+		    SIDHighWatermark	    "3749"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "J_LeftFoot"
@@ -20369,39 +20181,37 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4760::3745"
+		    SID			    "4760::3748"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    114
+		    ZOrder		    117
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4760::3744"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 14"
+		    SID			    "4760::3747"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 14"
 		    Ports		    [4, 2]
 		    Position		    [180, 102, 230, 203]
-		    ZOrder		    113
+		    ZOrder		    116
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Sat"
 		    PortCounts		    "[4 2]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "nu_b"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4760::3746"
+		    SID			    "4760::3749"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    115
+		    ZOrder		    118
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -20412,28 +20222,28 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    43
+		    ZOrder		    50
 		    SrcBlock		    "J_LeftFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    44
+		    ZOrder		    51
 		    SrcBlock		    "J_RightFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    45
+		    ZOrder		    52
 		    SrcBlock		    "feetInContact"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    46
+		    ZOrder		    53
 		    SrcBlock		    "sDot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -20441,7 +20251,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "nu_b"
-		    ZOrder		    47
+		    ZOrder		    54
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -20449,14 +20259,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    48
+		    ZOrder		    55
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    49
+		    ZOrder		    56
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -21115,7 +20925,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "99"
+		    SIDHighWatermark	    "102"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "s_0"
@@ -21262,81 +21072,65 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4671::98"
+		    SID			    "4671::101"
 		    Ports		    [1, 1]
 		    Position		    [270, 425, 320, 465]
-		    ZOrder		    85
+		    ZOrder		    88
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4671::97"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 10"
+		    SID			    "4671::100"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_2016b 10"
 		    Ports		    [16, 9]
 		    Position		    [180, 85, 230, 425]
-		    ZOrder		    84
+		    ZOrder		    87
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Config"
 		    PortCounts		    "[16 9]"
 		    SFunctionDeploymentMode off
-		    EnableBusSupport	    on
+		    EnableBusSupport	    off
 		    SFcnIsStateOwnerBlock   off
 		    Port {
 		    PortNumber		    2
 		    Name		    "state"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "references_CoM"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "references_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    5
 		    Name		    "references_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    6
 		    Name		    "references_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    7
 		    Name		    "feetInContact"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    8
 		    Name		    "references_s"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    9
 		    Name		    "w_H_b"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4671::99"
+		    SID			    "4671::102"
 		    Position		    [460, 436, 480, 454]
-		    ZOrder		    86
+		    ZOrder		    89
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -21410,112 +21204,112 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    859
+		    ZOrder		    885
 		    SrcBlock		    "s_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    860
+		    ZOrder		    886
 		    SrcBlock		    "w_H_CoM_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    861
+		    ZOrder		    887
 		    SrcBlock		    "w_H_LFoot_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    862
+		    ZOrder		    888
 		    SrcBlock		    "w_H_RFoot_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    863
+		    ZOrder		    889
 		    SrcBlock		    "w_H_rot_task_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    864
+		    ZOrder		    890
 		    SrcBlock		    "w_walking_H_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    6
 		    }
 		    Line {
-		    ZOrder		    865
+		    ZOrder		    891
 		    SrcBlock		    "w_walking_H_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    7
 		    }
 		    Line {
-		    ZOrder		    866
+		    ZOrder		    892
 		    SrcBlock		    "LFoot_H_b"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    8
 		    }
 		    Line {
-		    ZOrder		    867
+		    ZOrder		    893
 		    SrcBlock		    "RFoot_H_b"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    9
 		    }
 		    Line {
-		    ZOrder		    868
+		    ZOrder		    894
 		    SrcBlock		    "w_walking_H_b"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    10
 		    }
 		    Line {
-		    ZOrder		    869
+		    ZOrder		    895
 		    SrcBlock		    "t"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    11
 		    }
 		    Line {
-		    ZOrder		    870
+		    ZOrder		    896
 		    SrcBlock		    "pos_vel_acc_CoM_des_walking"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    12
 		    }
 		    Line {
-		    ZOrder		    871
+		    ZOrder		    897
 		    SrcBlock		    "s_des_walking"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    13
 		    }
 		    Line {
-		    ZOrder		    872
+		    ZOrder		    898
 		    SrcBlock		    "feetInContact_walking"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    14
 		    }
 		    Line {
-		    ZOrder		    873
+		    ZOrder		    899
 		    SrcBlock		    "LFoot_wrench"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    15
 		    }
 		    Line {
-		    ZOrder		    874
+		    ZOrder		    900
 		    SrcBlock		    "RFoot_wrench"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -21523,7 +21317,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "state"
-		    ZOrder		    875
+		    ZOrder		    901
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -21533,7 +21327,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "references_CoM"
-		    ZOrder		    876
+		    ZOrder		    902
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -21542,7 +21336,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "references_LFoot"
-		    ZOrder		    877
+		    ZOrder		    903
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -21551,7 +21345,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "references_RFoot"
-		    ZOrder		    878
+		    ZOrder		    904
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    5
@@ -21560,7 +21354,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "references_rot_task"
-		    ZOrder		    879
+		    ZOrder		    905
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    6
@@ -21569,7 +21363,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "feetInContact"
-		    ZOrder		    880
+		    ZOrder		    906
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    7
@@ -21578,7 +21372,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "references_s"
-		    ZOrder		    881
+		    ZOrder		    907
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    8
@@ -21587,7 +21381,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "w_H_b"
-		    ZOrder		    882
+		    ZOrder		    908
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    9
@@ -21595,14 +21389,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    883
+		    ZOrder		    909
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    884
+		    ZOrder		    910
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -23249,8 +23043,8 @@ Model {
 	  Variant		  off
 	  System {
 	    Name		    "Cartesian Tasks"
-	    Location		    [65, 24, 1920, 1080]
-	    Open		    on
+	    Location		    [61, 35, 1916, 1091]
+	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
 	    ScreenColor		    "white"
@@ -23417,7 +23211,7 @@ Model {
 	      "','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')"
 	      "}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLay"
 	      "outDimensions',[4 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale"
-	      "','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2016b','Location',[66 1"
+	      "','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 1"
 	      "06 1921 1079])"
 	      NumInputPorts	      "4"
 	    }
@@ -23489,7 +23283,7 @@ Model {
 	      "Width',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','non"
 	      "e','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placeme"
 	      "nt',1),'DisplayLayoutDimensions',[4 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,"
-	      "'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b"
+	      "'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a"
 	      "','Location',[66 78 1921 1079])"
 	      NumInputPorts	      "4"
 	    }
@@ -23539,7 +23333,7 @@ Model {
 	      "[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLi"
 	      "nes',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configurati"
 	      "on('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Me"
-	      "asurements',true,'Version','2016b')),'Version','2016b','Location',[66 171 1407 980])"
+	      "asurements',true,'Version','2016b')),'Version','2017a','Location',[66 171 1407 980])"
 	      NumInputPorts	      "2"
 	    }
 	    Block {
@@ -23588,7 +23382,7 @@ Model {
 	      "0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLin"
 	      "es',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuratio"
 	      "n('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Mea"
-	      "surements',true,'Version','2016b')),'Version','2016b','Location',[76 218 1387 937])"
+	      "surements',true,'Version','2016b')),'Version','2017a','Location',[76 218 1387 937])"
 	      NumInputPorts	      "2"
 	    }
 	    Block {
@@ -23596,7 +23390,7 @@ Model {
 	      Name		      "Norm of Rotation Error rot_task"
 	      SID		      "6222"
 	      Ports		      [2]
-	      Position		      [1665, 962, 1750, 1068]
+	      Position		      [1665, 964, 1750, 1071]
 	      ZOrder		      749
 	      ScopeSpecificationString "Simulink.scopes.TimeScopeBlockCfg('CurrentConfiguration', extmgr.ConfigurationSet(ext"
 	      "mgr.Configuration('Core','General UI',true,'FigureColor',[0.156862745098039 0.156862745098039 0.156862745098039"
@@ -23637,7 +23431,7 @@ Model {
 	      "],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0"
 	      ",'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('To"
 	      "ols','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurem"
-	      "ents',true,'Version','2016b')),'Version','2016b','Location',[66 140 1387 889])"
+	      "ents',true,'Version','2016b')),'Version','2017a','Location',[66 140 1387 889])"
 	      NumInputPorts	      "2"
 	    }
 	    Block {
@@ -23707,7 +23501,7 @@ Model {
 	      "Width',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','non"
 	      "e','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placeme"
 	      "nt',1),'DisplayLayoutDimensions',[4 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,"
-	      "'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b"
+	      "'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a"
 	      "','Location',[66 78 1921 1079])"
 	      NumInputPorts	      "4"
 	    }
@@ -24938,10 +24732,6 @@ Model {
 	      DstPort		      1
 	    }
 	    Line {
-	      FontName		      "Helvetica"
-	      FontSize		      9
-	      FontWeight	      "normal"
-	      FontAngle		      "normal"
 	      ZOrder		      68
 	      SrcBlock		      "orient_vel_Rot_task"
 	      SrcPort		      1
@@ -25142,14 +24932,10 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"force measured left foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"moments measured left foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25165,14 +24951,10 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"force measured right foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"moments measured right foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25188,14 +24970,10 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"force desired right foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"moments measured right foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25211,14 +24989,10 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"force desired left foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"moments measured left foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25239,32 +25013,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25285,32 +25049,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25331,32 +25085,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25404,7 +25148,7 @@ Model {
 	      "e','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'Us"
 	      "erDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDim"
 	      "ensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'"
-	      "),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[96 252 136"
+	      "),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[96 252 136"
 	      "7 851])"
 	      NumInputPorts	      "2"
 	    }
@@ -25438,8 +25182,6 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"force error left foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25458,8 +25200,6 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"moments measured left foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25478,8 +25218,6 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"force error right foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25498,8 +25236,6 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"moments measured right foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25591,7 +25327,7 @@ Model {
 	      "finedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'TimeRangeSamples','1"
 	      "4','TimeRangeFrames','14','DisplayLayoutDimensions',[6 1]),extmgr.Configuration('Tools','Plot Navigation',true,"
 	      "'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2017b'"
-	      ")),'Version','2017b','Location',[66 108 1367 797])"
+	      ")),'Version','2017a','Location',[66 108 1367 797])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -25664,7 +25400,7 @@ Model {
 	      "es',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'TimeRangeSamples','40','TimeRangeFr"
 	      "ames','40','DisplayLayoutDimensions',[4 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',fa"
 	      "lse,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2"
-	      "017b','Location',[66 78 1921 1079])"
+	      "017a','Location',[66 78 1921 1079])"
 	      NumInputPorts	      "4"
 	    }
 	    Block {
@@ -25737,7 +25473,7 @@ Model {
 	      "ChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'TimeRangeSamples','40','T"
 	      "imeRangeFrames','40','DisplayLayoutDimensions',[4 1]),extmgr.Configuration('Tools','Plot Navigation',true,'Once"
 	      "AtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'V"
-	      "ersion','2017b','Location',[66 78 1921 1079])"
+	      "ersion','2017a','Location',[66 78 1921 1079])"
 	      NumInputPorts	      "4"
 	    }
 	    Block {
@@ -25761,8 +25497,6 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"wL_WBDT"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25786,8 +25520,6 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"wR_WBDT"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25879,7 +25611,7 @@ Model {
 	      "inedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'TimeRangeSamples','14"
 	      "','TimeRangeFrames','14','DisplayLayoutDimensions',[6 1]),extmgr.Configuration('Tools','Plot Navigation',true,'"
 	      "OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')"
-	      "),'Version','2017b','Location',[76 108 1377 797])"
+	      "),'Version','2017a','Location',[76 108 1377 797])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -25950,7 +25682,7 @@ Model {
 	      "Width',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'Sh"
 	      "owContent',true,'Placement',1),'TimeRangeSamples','40','TimeRangeFrames','40','DisplayLayoutDimensions',[4 1]),"
 	      "extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false),extmgr.Configuration('Tools','Measureme"
-	      "nts',true,'Version','2017b')),'Version','2017b','Location',[66 78 1367 767])"
+	      "nts',true,'Version','2017b')),'Version','2017a','Location',[66 78 1367 767])"
 	      NumInputPorts	      "4"
 	    }
 	    Block {
@@ -26021,7 +25753,7 @@ Model {
 	      "e','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placeme"
 	      "nt',1),'TimeRangeSamples','40','TimeRangeFrames','40','DisplayLayoutDimensions',[4 1]),extmgr.Configuration('To"
 	      "ols','Plot Navigation',true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','201"
-	      "7b')),'Version','2017b','Location',[66 78 1367 767])"
+	      "7b')),'Version','2017a','Location',[66 78 1367 767])"
 	      NumInputPorts	      "4"
 	    }
 	    Block {
@@ -26115,7 +25847,7 @@ Model {
 	      "tyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNa"
 	      "mes',{{[]}},'ShowContent',true,'Placement',1),'TimeRangeSamples','14','TimeRangeFrames','14','DisplayLayoutDime"
 	      "nsions',[6 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY')"
-	      ",extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[355 406 164"
+	      ",extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[355 406 164"
 	      "6 1065])"
 	      NumInputPorts	      "6"
 	    }
@@ -27115,32 +26847,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -27161,32 +26883,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -27244,7 +26956,7 @@ Model {
 	      "35294117647 1 1;1 0.0745098039215686 0.650980392156863]),'DisplayLayoutDimensions',[3 2],'DisplayContentCache',"
 	      "{struct('Title','%<SignalLabel>','LinePropertiesCache',{{}},'UserDefinedChannelNames',{{}},'PlotMagPhase',false"
 	      ")}),extmgr.Configuration('Tools','Plot Navigation',true),extmgr.Configuration('Tools','Measurements',true,'Vers"
-	      "ion','2017b')),'Version','2017b','Position',[403 146 560 420])"
+	      "ion','2017b')),'Version','2017a','Position',[403 146 560 420])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -27302,7 +27014,7 @@ Model {
 	      "294117647 1 1;1 0.0745098039215686 0.650980392156863]),'DisplayLayoutDimensions',[3 2],'DisplayContentCache',{s"
 	      "truct('Title','%<SignalLabel>','LinePropertiesCache',{{}},'UserDefinedChannelNames',{{}},'PlotMagPhase',false)}"
 	      "),extmgr.Configuration('Tools','Plot Navigation',true),extmgr.Configuration('Tools','Measurements',true,'Versio"
-	      "n','2017b')),'Version','2017b','Position',[403 146 560 420])"
+	      "n','2017b')),'Version','2017a','Position',[403 146 560 420])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -27350,7 +27062,7 @@ Model {
 	      " 0],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','Lin"
 	      "eWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'S"
 	      "howContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation'"
-	      ",true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017b"
+	      ",true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017a"
 	      "','Location',[66 78 1367 767])"
 	      NumInputPorts	      "2"
 	    }
@@ -27399,7 +27111,7 @@ Model {
 	      "arker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible',"
 	      "'on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'Displ"
 	      "ayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAuto"
-	      "scale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',"
+	      "scale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',"
 	      "[333 390 1634 1079])"
 	      NumInputPorts	      "2"
 	    }
@@ -27449,7 +27161,7 @@ Model {
 	      ",0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowCont"
 	      "ent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'"
 	      "OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')"
-	      "),'Version','2017b','Location',[1345 525 2656 1244])"
+	      "),'Version','2017a','Location',[1345 525 2656 1244])"
 	      NumInputPorts	      "2"
 	    }
 	    Block {
@@ -27497,7 +27209,7 @@ Model {
 	      ",'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWi"
 	      "dth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'Show"
 	      "Content',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',tr"
-	      "ue,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017b','"
+	      "ue,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017a','"
 	      "Location',[66 78 1367 767])"
 	      NumInputPorts	      "2"
 	    }
@@ -27546,7 +27258,7 @@ Model {
 	      "arker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible',"
 	      "'on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'Displ"
 	      "ayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAuto"
-	      "scale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',"
+	      "scale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',"
 	      "[66 106 1377 825])"
 	      NumInputPorts	      "2"
 	    }
@@ -27596,7 +27308,7 @@ Model {
 	      "-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{"
 	      "[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navi"
 	      "gation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Ver"
-	      "sion','2016b')),'Version','2017b','Location',[66 134 1377 853])"
+	      "sion','2016b')),'Version','2017a','Location',[66 134 1377 853])"
 	      NumInputPorts	      "2"
 	    }
 	    Block {
@@ -27644,7 +27356,7 @@ Model {
 	      ",'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWi"
 	      "dth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'Show"
 	      "Content',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',tr"
-	      "ue,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017b','"
+	      "ue,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017a','"
 	      "Location',[66 78 1367 767])"
 	      NumInputPorts	      "2"
 	    }
@@ -27693,7 +27405,7 @@ Model {
 	      " 0],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','Lin"
 	      "eWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'S"
 	      "howContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation'"
-	      ",true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017b"
+	      ",true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017a"
 	      "','Location',[66 78 1367 767])"
 	      NumInputPorts	      "2"
 	    }
@@ -28052,32 +27764,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -28098,32 +27800,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -28144,32 +27836,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -28190,32 +27872,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -28348,7 +28020,7 @@ Model {
 	      "t('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{"
 	      "{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.C"
 	      "onfiguration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('"
-	      "Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[66 78 1921 1079])"
+	      "Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 78 1921 1079])"
 	      NumInputPorts	      "2"
 	    }
 	    Block {
@@ -28397,7 +28069,7 @@ Model {
 	      "th',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none',"
 	      "'Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement'"
 	      ",1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'Pr"
-	      "eviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','"
+	      "eviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','"
 	      "Location',[632 559 1943 1278])"
 	      NumInputPorts	      "2"
 	    }
@@ -28491,7 +28163,7 @@ Model {
 	      "',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'Num"
 	      "Lines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),extmgr.Configura"
 	      "tion('Tools','Plot Navigation',true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Versi"
-	      "on','2017b')),'Version','2017b','Location',[66 78 1367 767])"
+	      "on','2017b')),'Version','2017a','Location',[66 78 1367 767])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -28539,7 +28211,7 @@ Model {
 	      "Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible'"
 	      ",'on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'Disp"
 	      "layLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAut"
-	      "oscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location'"
+	      "oscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location'"
 	      ",[66 78 1921 1079])"
 	      NumInputPorts	      "2"
 	    }
@@ -28635,7 +28307,7 @@ Model {
 	      "',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'Num"
 	      "Lines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),extmgr.Configura"
 	      "tion('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','"
-	      "Measurements',true,'Version','2016b')),'Version','2017b','Location',[66 78 1921 1079])"
+	      "Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 78 1921 1079])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -28730,7 +28402,7 @@ Model {
 	      "lor',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'"
 	      "NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),extmgr.Config"
 	      "uration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools"
-	      "','Measurements',true,'Version','2016b')),'Version','2017b','Location',[431 355 1732 1044])"
+	      "','Measurements',true,'Version','2016b')),'Version','2017a','Location',[431 355 1732 1044])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -28824,7 +28496,7 @@ Model {
 	      "rker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','"
 	      "on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'Displa"
 	      "yLayoutDimensions',[6 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutos"
-	      "cale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',["
+	      "cale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',["
 	      "512 390 1813 1079])"
 	      NumInputPorts	      "6"
 	    }
@@ -29505,7 +29177,7 @@ Model {
 	      "arker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible',"
 	      "'on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1)),extmg"
 	      "r.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuratio"
-	      "n('Tools','Measurements',true,'Version','2016b')),'Version','2016b','Location',[66 109 1387 858])"
+	      "n('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 109 1387 858])"
 	      NumInputPorts	      "1"
 	    }
 	    Block {
@@ -29545,7 +29217,7 @@ Model {
 	      "'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible"
 	      "','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1)),ext"
 	      "mgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configurat"
-	      "ion('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[640 199 1220 679])"
+	      "ion('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[640 199 1220 679])"
 	      NumInputPorts	      "1"
 	    }
 	    Block {
@@ -29594,7 +29266,7 @@ Model {
 	      "none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},"
 	      "'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayout"
 	      "Dimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','"
-	      "XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2016b','Location',[66 140 "
+	      "XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 140 "
 	      "1397 919])"
 	      NumInputPorts	      "1"
 	    }
@@ -29644,7 +29316,7 @@ Model {
 	      "','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedCh"
 	      "annelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2"
 	      " 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Co"
-	      "nfiguration('Tools','Measurements',true,'Version','2016b')),'Version','2016b','Location',[76 162 1387 881])"
+	      "nfiguration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[76 162 1387 881])"
 	      NumInputPorts	      "1"
 	    }
 	    Block {
@@ -29693,7 +29365,7 @@ Model {
 	      "e','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'Us"
 	      "erDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDim"
 	      "ensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'"
-	      "),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2016b','Location',[66 109 138"
+	      "),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 109 138"
 	      "7 858])"
 	      NumInputPorts	      "1"
 	    }
@@ -29734,7 +29406,7 @@ Model {
 	      "none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},"
 	      "'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1)),extmgr.Config"
 	      "uration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools"
-	      "','Measurements',true,'Version','2016b')),'Version','2017b','Location',[403 294 943 654])"
+	      "','Measurements',true,'Version','2016b')),'Version','2017a','Location',[403 294 943 654])"
 	      NumInputPorts	      "1"
 	    }
 	    Block {
@@ -29773,7 +29445,7 @@ Model {
 	      ",'Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'User"
 	      "DefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1)),extmgr.Configurati"
 	      "on('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Me"
-	      "asurements',true,'Version','2016b')),'Version','2017b','Location',[655 257 1235 737])"
+	      "asurements',true,'Version','2016b')),'Version','2017a','Location',[655 257 1235 737])"
 	      NumInputPorts	      "1"
 	    }
 	    Block {
@@ -29928,7 +29600,7 @@ Model {
 		  BlockType		  Outport
 		  Name			  "|1-R^T*RDes|^2"
 		  SID			  "6182"
-		  Position		  [802, 8, 832, 22]
+		  Position		  [800, 8, 830, 22]
 		  ZOrder		  38
 		  IconDisplay		  "Port number"
 		}
@@ -30194,7 +29866,7 @@ Model {
 		  BlockType		  Outport
 		  Name			  "|1-R^T*RDes|^2"
 		  SID			  "6186"
-		  Position		  [916, 88, 946, 102]
+		  Position		  [915, 88, 945, 102]
 		  ZOrder		  39
 		  IconDisplay		  "Port number"
 		}
@@ -30460,7 +30132,7 @@ Model {
 		  BlockType		  Outport
 		  Name			  "|1-R^T*RDes|^2"
 		  SID			  "6190"
-		  Position		  [892, 68, 922, 82]
+		  Position		  [890, 68, 920, 82]
 		  ZOrder		  40
 		  IconDisplay		  "Port number"
 		}
@@ -30610,7 +30282,7 @@ Model {
 	      "on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChann"
 	      "elNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1)),extmgr.Configuration('Tools','"
 	      "Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',"
-	      "true,'Version','2016b')),'Version','2017b','Location',[128 253 1439 972])"
+	      "true,'Version','2016b')),'Version','2017a','Location',[128 253 1439 972])"
 	      NumInputPorts	      "1"
 	    }
 	    Block {
@@ -30651,7 +30323,7 @@ Model {
 	      "Width',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','non"
 	      "e','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placeme"
 	      "nt',1)),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr"
-	      ".Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[660 254 1260 794])"
+	      ".Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[660 254 1260 794])"
 	      NumInputPorts	      "1"
 	    }
 	    Line {
@@ -31593,13 +31265,13 @@ Model {
 }
 #Finite State Machines
 #
-#   Stateflow 80000010
+#   Stateflow 80000011
 #
 #
 Stateflow {
   machine {
     id			    1
-    name		    "torqueWalkingMPC"
+    name		    "torqueWalkingMPC_2016b"
     created		    "29-Nov-2017 15:01:26"
     isLibrary		    0
     sfVersion		    80000010

--- a/controllers/torqueWalkingMPC/torqueWalkingMPC.mdl
+++ b/controllers/torqueWalkingMPC/torqueWalkingMPC.mdl
@@ -1,12 +1,12 @@
 Model {
-  Name			  "torqueWalkingMPC"
+  Name			  "torqueWalkingMPC_R2016b"
   Version		  8.8
   SavedCharacterEncoding  "UTF-8"
   GraphicalInterface {
     NumRootInports	    0
     NumRootOutports	    0
     ParameterArgumentNames  ""
-    ComputedModelVersion    "1.504"
+    ComputedModelVersion    "1.508"
     NumModelReferences	    0
     NumTestPointedSignals   0
     NumProvidedFunctions    0
@@ -20,7 +20,7 @@ Model {
   LogicAnalyzerPlugin	  "on"
   LogicAnalyzerSignalOrdering ""
   DiagnosticSuppressor	  "on"
-  SuppressorTable	  "22 serialization::archive 11 0 3 0 0 0 11 0"
+  SuppressorTable	  "22 serialization::archive 11 0 6 0 0 0 11 0"
   ScopeRefreshTime	  0.035000
   OverrideScopeRefreshTime on
   DisableAllScopes	  off
@@ -41,7 +41,7 @@ Model {
       $ObjectID		      2
       $ClassName	      "Simulink.WindowInfo"
       IsActive		      [1]
-      Location		      [65.0, 24.0, 1855.0, 1056.0]
+      Location		      [53.0, 27.0, 1313.0, 741.0]
       Object {
 	$PropName		"ModelBrowserInfo"
 	$ObjectID		3
@@ -63,21 +63,21 @@ Model {
 	Dimension		2
 	Object {
 	  $ObjectID		  5
-	  IsActive		  [0]
-	  ViewObjType		  "SimulinkTopLevel"
-	  LoadSaveID		  "0"
-	  Extents		  [1821.0, 905.0]
-	  ZoomFactor		  [1.2050300656648256]
-	  Offset		  [-335.58280738636108, -60.379767408639168]
+	  IsActive		  [1]
+	  ViewObjType		  "SimulinkSubsys"
+	  LoadSaveID		  "5241"
+	  Extents		  [1275.0, 558.0]
+	  ZoomFactor		  [1.2100456621004567]
+	  Offset		  [-572.37868514150944, 267.4301886792453]
 	}
 	Object {
 	  $ObjectID		  6
-	  IsActive		  [1]
+	  IsActive		  [0]
 	  ViewObjType		  "SimulinkSubsys"
 	  LoadSaveID		  "4470"
-	  Extents		  [1821.0, 905.0]
+	  Extents		  [1366.0, 768.0]
 	  ZoomFactor		  [1.3218562874251496]
-	  Offset		  [495.7545167398074, 405.4088335220838]
+	  Offset		  [495.75451673980763, 405.4088335220838]
 	}
 	PropName		"EditorsInfo"
       }
@@ -97,24 +97,24 @@ Model {
       }
       WindowState	      "AAAA/wAAAAD9AAAAAgAAAAAAAAC9AAAB+PwCAAAAA/sAAAAWAEQAbwBjAGsAVwBpAGQAZwBlAHQAMwEAAAAxAAAB+AAAA"
       "AAAAAAA+wAAABYARABvAGMAawBXAGkAZABnAGUAdAA0AAAAAAD/////AAAAAAAAAAD7AAAAUgBHAEwAVQBFADIAIAB0AHIAZQBlACAAYwBvAG0Ac"
-      "ABvAG4AZQBuAHQALwBHAEwAVQBFADIAIAB0AHIAZQBlACAAYwBvAG0AcABvAG4AZQBuAHQAAAAAAP////8AAABeAP///wAAAAEAAAAAAAAAAPwCA"
+      "ABvAG4AZQBuAHQALwBHAEwAVQBFADIAIAB0AHIAZQBlACAAYwBvAG0AcABvAG4AZQBuAHQAAAAAAP////8AAABiAP///wAAAAEAAAAAAAAAAPwCA"
       "AAAAfsAAABUAEcATABVAEUAMgA6AFAAcgBvAHAAZQByAHQAeQBJAG4AcwBwAGUAYwB0AG8AcgAvAFAAcgBvAHAAZQByAHQAeQAgAEkAbgBzAHAAZ"
-      "QBjAHQAbwByAAAAAAD/////AAAAKAD///8AAAc/AAADyQAAAAEAAAACAAAAAQAAAAL8AAAAAQAAAAIAAAAP/////wAAAAAA/////wAAAAAAAAAA/"
+      "QBjAHQAbwByAAAAAAD/////AAAALAD///8AAAUhAAACcgAAAAEAAAACAAAAAQAAAAL8AAAAAQAAAAIAAAAP/////wAAAAAA/////wAAAAAAAAAA/"
       "////wEAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/"
       "////wEAAACA/////wAAAAAAAAAA/////wEAAADo/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wEAAAFo/////wAAAAAAAAAA/"
-      "////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wEAAANR/////wAAAAAAAAAA/"
-      "////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA"
+      "////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA/////wEAAAOH/////wAAAAAAAAAA/"
+      "////wEAAAO5/////wAAAAAAAAAA/////wAAAAAA/////wAAAAAAAAAA"
     }
   }
   Created		  "Wed Nov 29 15:01:02 2017"
   Creator		  "gnava"
   UpdateHistory		  "UpdateHistoryNever"
   ModifiedByFormat	  "%<Auto>"
-  LastModifiedBy	  "gnava"
+  LastModifiedBy	  "mcharbonneau"
   ModifiedDateFormat	  "%<Auto>"
-  LastModifiedDate	  "Fri Jan 19 16:51:13 2018"
-  RTWModifiedTimeStamp	  438281381
-  ModelVersionFormat	  "1.%<AutoIncrement:504>"
+  LastModifiedDate	  "Wed Feb 28 11:38:17 2018"
+  RTWModifiedTimeStamp	  441718696
+  ModelVersionFormat	  "1.%<AutoIncrement:508>"
   ConfigurationManager	  "none"
   SampleTimeColors	  off
   SampleTimeAnnotations	  off
@@ -164,12 +164,12 @@ Model {
     $PropName		    "DataLoggingOverride"
     $ObjectID		    8
     $ClassName		    "Simulink.SimulationData.ModelLoggingInfo"
-    model_		    "torqueWalkingMPC"
+    model_		    "torqueWalkingMPC_R2016b"
     overrideMode_	    [0.0]
     Array {
       Type		      "Cell"
       Dimension		      1
-      Cell		      "torqueWalkingMPC"
+      Cell		      "torqueWalkingMPC_R2016b"
       PropName		      "logAsSpecifiedByModels_"
     }
     Array {
@@ -754,7 +754,6 @@ Model {
 	      CodeReplacementLibrary  "None"
 	      UtilityFuncGeneration   "Auto"
 	      ERTMultiwordTypeDef     "System defined"
-	      ERTMultiwordLength      256
 	      MultiwordLength	      2048
 	      GenerateFullHeader      on
 	      InferredTypesCompatibility off
@@ -861,7 +860,7 @@ Model {
       Name		      "Configuration"
       ExtraOptions	      ""
       CurrentDlgPage	      "Solver"
-      ConfigPrmDlgPosition     [ 81, 81, 951, 689 ] 
+      ConfigPrmDlgPosition    [ 81, 81, 951, 689 ]
     }
     PropName		    "ConfigurationSets"
   }
@@ -1056,7 +1055,6 @@ Model {
     }
     Block {
       BlockType		      M-S-Function
-      FunctionName	      "matlabfile"
       DisplayMFileStacktrace  on
     }
     Block {
@@ -1085,6 +1083,7 @@ Model {
       SourceOfInitialOutputValue "Dialog"
       OutputWhenDisabled      "held"
       InitialOutput	      "[]"
+      MustResolveToSignalObject	off
     }
     Block {
       BlockType		      PermuteDimensions
@@ -1214,9 +1213,9 @@ Model {
     }
   }
   System {
-    Name		    "torqueWalkingMPC"
-    Location		    [65, 24, 1920, 1080]
-    Open		    on
+    Name		    "torqueWalkingMPC_R2016b"
+    Location		    [61, 35, 1916, 1091]
+    Open		    off
     ModelBrowserVisibility  off
     ModelBrowserWidth	    200
     ScreenColor		    "white"
@@ -1427,7 +1426,7 @@ Model {
 	    TiledPageScale	    1
 	    ShowPageBoundaries	    off
 	    ZoomFactor		    "100"
-	    SIDHighWatermark	    "89"
+	    SIDHighWatermark	    "95"
 	    Block {
 	      BlockType		      Inport
 	      Name		      "feetInContact"
@@ -1565,20 +1564,20 @@ Model {
 	    Block {
 	      BlockType		      Demux
 	      Name		      " Demux "
-	      SID		      "4109::88"
+	      SID		      "4109::94"
 	      Ports		      [1, 1]
 	      Position		      [270, 350, 320, 390]
-	      ZOrder		      78
+	      ZOrder		      84
 	      Outputs		      "1"
 	    }
 	    Block {
 	      BlockType		      S-Function
 	      Name		      " SFunction "
-	      SID		      "4109::87"
-	      Tag		      "Stateflow S-Function torqueWalkingMPC 2"
+	      SID		      "4109::93"
+	      Tag		      "Stateflow S-Function torqueWalkingMPC_R2016b 2"
 	      Ports		      [15, 7]
 	      Position		      [180, 85, 230, 405]
-	      ZOrder		      77
+	      ZOrder		      83
 	      FunctionName	      "sf_sfun"
 	      Parameters	      "Sat"
 	      PortCounts	      "[15 7]"
@@ -1588,46 +1587,34 @@ Model {
 	      Port {
 		PortNumber		2
 		Name			"Hessian"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"gradient"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"ConstraintMatrix_equality"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"biasVectorConstraint_equality"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		6
 		Name			"ConstraintMatrix_inequality"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		7
 		Name			"biasVectorConstraint_inequality"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
 	      BlockType		      Terminator
 	      Name		      " Terminator "
-	      SID		      "4109::89"
+	      SID		      "4109::95"
 	      Position		      [460, 361, 480, 379]
-	      ZOrder		      79
+	      ZOrder		      85
 	    }
 	    Block {
 	      BlockType		      Outport
@@ -1683,105 +1670,105 @@ Model {
 	      IconDisplay	      "Port number"
 	    }
 	    Line {
-	      ZOrder		      139
+	      ZOrder		      185
 	      SrcBlock		      "feetInContact"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      1
 	    }
 	    Line {
-	      ZOrder		      140
+	      ZOrder		      186
 	      SrcBlock		      "M"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      2
 	    }
 	    Line {
-	      ZOrder		      141
+	      ZOrder		      187
 	      SrcBlock		      "h"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      3
 	    }
 	    Line {
-	      ZOrder		      142
+	      ZOrder		      188
 	      SrcBlock		      "J"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      4
 	    }
 	    Line {
-	      ZOrder		      143
+	      ZOrder		      189
 	      SrcBlock		      "impedances"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      5
 	    }
 	    Line {
-	      ZOrder		      144
+	      ZOrder		      190
 	      SrcBlock		      "dampings"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      6
 	    }
 	    Line {
-	      ZOrder		      145
+	      ZOrder		      191
 	      SrcBlock		      "s"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      7
 	    }
 	    Line {
-	      ZOrder		      146
+	      ZOrder		      192
 	      SrcBlock		      "sDot"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      8
 	    }
 	    Line {
-	      ZOrder		      147
+	      ZOrder		      193
 	      SrcBlock		      "s_sDot_sDDot_des"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      9
 	    }
 	    Line {
-	      ZOrder		      148
+	      ZOrder		      194
 	      SrcBlock		      "acc_task_star"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      10
 	    }
 	    Line {
-	      ZOrder		      149
+	      ZOrder		      195
 	      SrcBlock		      "JDot_nu"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      11
 	    }
 	    Line {
-	      ZOrder		      150
+	      ZOrder		      196
 	      SrcBlock		      "ConstraintsMatrix_feet"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      12
 	    }
 	    Line {
-	      ZOrder		      151
+	      ZOrder		      197
 	      SrcBlock		      "biasVectorConstraint_feet"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      13
 	    }
 	    Line {
-	      ZOrder		      152
+	      ZOrder		      198
 	      SrcBlock		      "w_H_l_sole"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
 	      DstPort		      14
 	    }
 	    Line {
-	      ZOrder		      153
+	      ZOrder		      199
 	      SrcBlock		      "w_H_r_sole"
 	      SrcPort		      1
 	      DstBlock		      " SFunction "
@@ -1789,7 +1776,7 @@ Model {
 	    }
 	    Line {
 	      Name		      "Hessian"
-	      ZOrder		      154
+	      ZOrder		      200
 	      Labels		      [0, 0]
 	      SrcBlock		      " SFunction "
 	      SrcPort		      2
@@ -1798,7 +1785,7 @@ Model {
 	    }
 	    Line {
 	      Name		      "gradient"
-	      ZOrder		      155
+	      ZOrder		      201
 	      Labels		      [0, 0]
 	      SrcBlock		      " SFunction "
 	      SrcPort		      3
@@ -1807,7 +1794,7 @@ Model {
 	    }
 	    Line {
 	      Name		      "ConstraintMatrix_equality"
-	      ZOrder		      156
+	      ZOrder		      202
 	      Labels		      [0, 0]
 	      SrcBlock		      " SFunction "
 	      SrcPort		      4
@@ -1816,7 +1803,7 @@ Model {
 	    }
 	    Line {
 	      Name		      "biasVectorConstraint_equality"
-	      ZOrder		      157
+	      ZOrder		      203
 	      Labels		      [0, 0]
 	      SrcBlock		      " SFunction "
 	      SrcPort		      5
@@ -1825,7 +1812,7 @@ Model {
 	    }
 	    Line {
 	      Name		      "ConstraintMatrix_inequality"
-	      ZOrder		      158
+	      ZOrder		      204
 	      Labels		      [0, 0]
 	      SrcBlock		      " SFunction "
 	      SrcPort		      6
@@ -1834,7 +1821,7 @@ Model {
 	    }
 	    Line {
 	      Name		      "biasVectorConstraint_inequality"
-	      ZOrder		      159
+	      ZOrder		      205
 	      Labels		      [0, 0]
 	      SrcBlock		      " SFunction "
 	      SrcPort		      7
@@ -1842,14 +1829,14 @@ Model {
 	      DstPort		      1
 	    }
 	    Line {
-	      ZOrder		      160
+	      ZOrder		      206
 	      SrcBlock		      " Demux "
 	      SrcPort		      1
 	      DstBlock		      " Terminator "
 	      DstPort		      1
 	    }
 	    Line {
-	      ZOrder		      161
+	      ZOrder		      207
 	      SrcBlock		      " SFunction "
 	      SrcPort		      1
 	      DstBlock		      " Demux "
@@ -3704,7 +3691,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "22"
+		    SIDHighWatermark	    "28"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "M"
@@ -3716,20 +3703,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "6165::20"
+		    SID			    "6165::27"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    11
+		    ZOrder		    17
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "6165::19"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 20"
+		    SID			    "6165::26"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 20"
 		    Ports		    [1, 2]
 		    Position		    [180, 100, 230, 160]
-		    ZOrder		    10
+		    ZOrder		    16
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Config"
 		    PortCounts		    "[1 2]"
@@ -3739,16 +3726,14 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "M_with_inertia"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "6165::21"
+		    SID			    "6165::28"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    12
+		    ZOrder		    18
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -3759,7 +3744,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    1
+		    ZOrder		    9
 		    SrcBlock		    "M"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -3767,7 +3752,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "M_with_inertia"
-		    ZOrder		    2
+		    ZOrder		    10
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -3775,14 +3760,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    3
+		    ZOrder		    11
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    4
+		    ZOrder		    12
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -4745,7 +4730,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "3746"
+		    SIDHighWatermark	    "3752"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "J_LeftFoot"
@@ -4784,20 +4769,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "5626::3745"
+		    SID			    "5626::3751"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    114
+		    ZOrder		    120
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "5626::3744"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 1"
+		    SID			    "5626::3750"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 1"
 		    Ports		    [4, 2]
 		    Position		    [180, 102, 230, 203]
-		    ZOrder		    113
+		    ZOrder		    119
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Sat"
 		    PortCounts		    "[4 2]"
@@ -4807,16 +4792,14 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "nu_b"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "5626::3746"
+		    SID			    "5626::3752"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    115
+		    ZOrder		    121
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -4827,28 +4810,28 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    43
+		    ZOrder		    57
 		    SrcBlock		    "J_LeftFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    44
+		    ZOrder		    58
 		    SrcBlock		    "J_RightFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    45
+		    ZOrder		    59
 		    SrcBlock		    "feetInContact"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    46
+		    ZOrder		    60
 		    SrcBlock		    "sDot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -4856,7 +4839,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "nu_b"
-		    ZOrder		    47
+		    ZOrder		    61
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -4864,14 +4847,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    48
+		    ZOrder		    62
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    49
+		    ZOrder		    63
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -5473,7 +5456,7 @@ Model {
 		TiledPageScale		1
 		ShowPageBoundaries	off
 		ZoomFactor		"100"
-		SIDHighWatermark	"79"
+		SIDHighWatermark	"85"
 		Block {
 		  BlockType		  Inport
 		  Name			  "pos_vel_acc_CoM_des"
@@ -5593,20 +5576,20 @@ Model {
 		Block {
 		  BlockType		  Demux
 		  Name			  " Demux "
-		  SID			  "4279::78"
+		  SID			  "4279::84"
 		  Ports			  [1, 1]
 		  Position		  [270, 230, 320, 270]
-		  ZOrder		  68
+		  ZOrder		  74
 		  Outputs		  "1"
 		}
 		Block {
 		  BlockType		  S-Function
 		  Name			  " SFunction "
-		  SID			  "4279::77"
-		  Tag			  "Stateflow S-Function torqueWalkingMPC 3"
+		  SID			  "4279::83"
+		  Tag			  "Stateflow S-Function torqueWalkingMPC_R2016b 3"
 		  Ports			  [13, 2]
 		  Position		  [180, 90, 230, 370]
-		  ZOrder		  67
+		  ZOrder		  73
 		  FunctionName		  "sf_sfun"
 		  Parameters		  "Sat"
 		  PortCounts		  "[13 2]"
@@ -5616,16 +5599,14 @@ Model {
 		  Port {
 		    PortNumber		    2
 		    Name		    "acc_task_star"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
 		  BlockType		  Terminator
 		  Name			  " Terminator "
-		  SID			  "4279::79"
+		  SID			  "4279::85"
 		  Position		  [460, 241, 480, 259]
-		  ZOrder		  69
+		  ZOrder		  75
 		}
 		Block {
 		  BlockType		  Outport
@@ -5636,91 +5617,91 @@ Model {
 		  IconDisplay		  "Port number"
 		}
 		Line {
-		  ZOrder		  97
+		  ZOrder		  129
 		  SrcBlock		  "pos_vel_acc_CoM_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  98
+		  ZOrder		  130
 		  SrcBlock		  "pose_vel_acc_LFoot_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  2
 		}
 		Line {
-		  ZOrder		  99
+		  ZOrder		  131
 		  SrcBlock		  "pose_vel_acc_RFoot_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  3
 		}
 		Line {
-		  ZOrder		  100
+		  ZOrder		  132
 		  SrcBlock		  "orient_vel_acc_rot_task_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  4
 		}
 		Line {
-		  ZOrder		  101
+		  ZOrder		  133
 		  SrcBlock		  "pos_vel_CoM"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  5
 		}
 		Line {
-		  ZOrder		  102
+		  ZOrder		  134
 		  SrcBlock		  "pose_vel_LFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  6
 		}
 		Line {
-		  ZOrder		  103
+		  ZOrder		  135
 		  SrcBlock		  "pose_vel_RFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  7
 		}
 		Line {
-		  ZOrder		  104
+		  ZOrder		  136
 		  SrcBlock		  "orient_vel_rot_task"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  8
 		}
 		Line {
-		  ZOrder		  105
+		  ZOrder		  137
 		  SrcBlock		  "Kp_Kd_CoM"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  9
 		}
 		Line {
-		  ZOrder		  106
+		  ZOrder		  138
 		  SrcBlock		  "Kp_Kd_LFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  10
 		}
 		Line {
-		  ZOrder		  107
+		  ZOrder		  139
 		  SrcBlock		  "Kp_Kd_RFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  11
 		}
 		Line {
-		  ZOrder		  108
+		  ZOrder		  140
 		  SrcBlock		  "Kp_Kd_rot_task"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  12
 		}
 		Line {
-		  ZOrder		  109
+		  ZOrder		  141
 		  SrcBlock		  "feetInContact"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
@@ -5728,7 +5709,7 @@ Model {
 		}
 		Line {
 		  Name			  "acc_task_star"
-		  ZOrder		  110
+		  ZOrder		  142
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  2
@@ -5736,14 +5717,14 @@ Model {
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  111
+		  ZOrder		  143
 		  SrcBlock		  " Demux "
 		  SrcPort		  1
 		  DstBlock		  " Terminator "
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  112
+		  ZOrder		  144
 		  SrcBlock		  " SFunction "
 		  SrcPort		  1
 		  DstBlock		  " Demux "
@@ -5865,7 +5846,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "94"
+		    SIDHighWatermark	    "100"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "vel_CoM"
@@ -5940,20 +5921,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4288::93"
+		    SID			    "4288::99"
 		    Ports		    [1, 1]
 		    Position		    [270, 280, 320, 320]
-		    ZOrder		    84
+		    ZOrder		    90
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4288::92"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 4"
+		    SID			    "4288::98"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 4"
 		    Ports		    [8, 5]
 		    Position		    [180, 100, 230, 280]
-		    ZOrder		    83
+		    ZOrder		    89
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[8 5]"
 		    SFunctionDeploymentMode off
@@ -5962,34 +5943,26 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "pos_vel_CoM"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "pose_vel_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "pose_vel_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    5
 		    Name		    "orient_vel_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4288::94"
+		    SID			    "4288::100"
 		    Position		    [460, 291, 480, 309]
-		    ZOrder		    85
+		    ZOrder		    91
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -6027,56 +6000,56 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    85
+		    ZOrder		    113
 		    SrcBlock		    "vel_CoM"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    86
+		    ZOrder		    114
 		    SrcBlock		    "vel_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    87
+		    ZOrder		    115
 		    SrcBlock		    "vel_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    88
+		    ZOrder		    116
 		    SrcBlock		    "vel_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    89
+		    ZOrder		    117
 		    SrcBlock		    "w_H_CoM"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    90
+		    ZOrder		    118
 		    SrcBlock		    "w_H_l_sole"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    6
 		    }
 		    Line {
-		    ZOrder		    91
+		    ZOrder		    119
 		    SrcBlock		    "w_H_r_sole"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    7
 		    }
 		    Line {
-		    ZOrder		    92
+		    ZOrder		    120
 		    SrcBlock		    "w_H_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -6084,7 +6057,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pos_vel_CoM"
-		    ZOrder		    93
+		    ZOrder		    121
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -6093,7 +6066,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pose_vel_LFoot"
-		    ZOrder		    94
+		    ZOrder		    122
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -6102,7 +6075,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pose_vel_RFoot"
-		    ZOrder		    95
+		    ZOrder		    123
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -6111,7 +6084,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "orient_vel_rot_task"
-		    ZOrder		    96
+		    ZOrder		    124
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    5
@@ -6119,14 +6092,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    97
+		    ZOrder		    125
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    98
+		    ZOrder		    126
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    Points		    [20, 0]
@@ -7316,7 +7289,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "64"
+		    SIDHighWatermark	    "70"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "s"
@@ -7391,20 +7364,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4342::63"
+		    SID			    "4342::69"
 		    Ports		    [1, 1]
 		    Position		    [270, 280, 320, 320]
-		    ZOrder		    54
+		    ZOrder		    60
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4342::62"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 5"
+		    SID			    "4342::68"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 5"
 		    Ports		    [8, 5]
 		    Position		    [180, 100, 230, 280]
-		    ZOrder		    53
+		    ZOrder		    59
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[8 5]"
 		    SFunctionDeploymentMode off
@@ -7413,34 +7386,26 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "Hessian"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "gradient"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "ConstraintMatrix"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    5
 		    Name		    "biasVectorConstraint"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4342::64"
+		    SID			    "4342::70"
 		    Position		    [460, 291, 480, 309]
-		    ZOrder		    55
+		    ZOrder		    61
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -7478,56 +7443,56 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    85
+		    ZOrder		    113
 		    SrcBlock		    "s"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    86
+		    ZOrder		    114
 		    SrcBlock		    "nu"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    87
+		    ZOrder		    115
 		    SrcBlock		    "s_sDot_sDDot_ref"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    88
+		    ZOrder		    116
 		    SrcBlock		    "impedances"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    89
+		    ZOrder		    117
 		    SrcBlock		    "dampings"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    90
+		    ZOrder		    118
 		    SrcBlock		    "J"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    6
 		    }
 		    Line {
-		    ZOrder		    91
+		    ZOrder		    119
 		    SrcBlock		    "JDot_nu"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    7
 		    }
 		    Line {
-		    ZOrder		    92
+		    ZOrder		    120
 		    SrcBlock		    "acc_task_star"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -7535,7 +7500,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "Hessian"
-		    ZOrder		    93
+		    ZOrder		    121
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -7544,7 +7509,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "gradient"
-		    ZOrder		    94
+		    ZOrder		    122
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -7553,7 +7518,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "ConstraintMatrix"
-		    ZOrder		    95
+		    ZOrder		    123
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -7562,7 +7527,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "biasVectorConstraint"
-		    ZOrder		    96
+		    ZOrder		    124
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    5
@@ -7570,14 +7535,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    97
+		    ZOrder		    125
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    98
+		    ZOrder		    126
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    Points		    [20, 0]
@@ -7808,7 +7773,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "65"
+		    SIDHighWatermark	    "71"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "pose_b"
@@ -7829,20 +7794,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4356::64"
+		    SID			    "4356::70"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    50
+		    ZOrder		    56
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4356::63"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 16"
+		    SID			    "4356::69"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 16"
 		    Ports		    [2, 2]
 		    Position		    [180, 100, 230, 160]
-		    ZOrder		    49
+		    ZOrder		    55
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[2 2]"
 		    SFunctionDeploymentMode off
@@ -7851,16 +7816,14 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "pose_bDot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4356::65"
+		    SID			    "4356::71"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    51
+		    ZOrder		    57
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -7871,7 +7834,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    36
+		    ZOrder		    46
 		    SrcBlock		    "pose_b"
 		    SrcPort		    1
 		    Points		    [120, 0]
@@ -7879,7 +7842,7 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    37
+		    ZOrder		    47
 		    SrcBlock		    "nu_b"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -7887,7 +7850,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pose_bDot"
-		    ZOrder		    38
+		    ZOrder		    48
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -7895,14 +7858,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    39
+		    ZOrder		    49
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    40
+		    ZOrder		    50
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -8058,7 +8021,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "64"
+		    SIDHighWatermark	    "70"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "w_H_b_0"
@@ -8070,20 +8033,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4363::63"
+		    SID			    "4363::69"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    49
+		    ZOrder		    55
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4363::62"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 18"
+		    SID			    "4363::68"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 18"
 		    Ports		    [1, 2]
 		    Position		    [180, 100, 230, 160]
-		    ZOrder		    48
+		    ZOrder		    54
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[1 2]"
 		    SFunctionDeploymentMode off
@@ -8092,16 +8055,14 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "pose_b_0"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4363::64"
+		    SID			    "4363::70"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    50
+		    ZOrder		    56
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -8112,7 +8073,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    25
+		    ZOrder		    33
 		    SrcBlock		    "w_H_b_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -8120,7 +8081,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pose_b_0"
-		    ZOrder		    26
+		    ZOrder		    34
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -8128,14 +8089,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    27
+		    ZOrder		    35
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    28
+		    ZOrder		    36
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -8172,7 +8133,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "64"
+		    SIDHighWatermark	    "70"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "pose_b"
@@ -8184,20 +8145,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4364::63"
+		    SID			    "4364::69"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    49
+		    ZOrder		    55
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4364::62"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 15"
+		    SID			    "4364::68"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 15"
 		    Ports		    [1, 2]
 		    Position		    [180, 100, 230, 160]
-		    ZOrder		    48
+		    ZOrder		    54
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[1 2]"
 		    SFunctionDeploymentMode off
@@ -8206,16 +8167,14 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "w_H_b"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4364::64"
+		    SID			    "4364::70"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    50
+		    ZOrder		    56
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -8226,7 +8185,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    25
+		    ZOrder		    33
 		    SrcBlock		    "pose_b"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -8234,7 +8193,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "w_H_b"
-		    ZOrder		    26
+		    ZOrder		    34
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -8242,14 +8201,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    27
+		    ZOrder		    35
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    28
+		    ZOrder		    36
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -8878,32 +8837,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -8924,32 +8873,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -8970,32 +8909,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -9016,32 +8945,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -9062,32 +8981,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -9108,32 +9017,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -9154,32 +9053,22 @@ Model {
 		  Port {
 		    PortNumber		    1
 		    Name		    "torso"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    2
 		    Name		    "left_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "right_arm"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "left_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "right_leg"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
@@ -9281,7 +9170,7 @@ Model {
 		  "rker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on'"
 		  ")}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayou"
 		  "tDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY"
-		  "'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[66 106 1377 "
+		  "'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 106 1377 "
 		  "825])"
 		  NumInputPorts		  "1"
 		}
@@ -9434,7 +9323,7 @@ Model {
 		  "tyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames"
 		  "',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Nav"
 		  "igation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Versi"
-		  "on','2016b')),'Version','2017b','Location',[66 109 1377 828])"
+		  "on','2016b')),'Version','2017a','Location',[66 109 1377 828])"
 		  NumInputPorts		  "1"
 		}
 		Block {
@@ -9526,7 +9415,7 @@ Model {
 		  "uct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{"
 		  "}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),extmgr.Confi"
 		  "guration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools',"
-		  "'Measurements',true,'Version','2016b')),'Version','2017b','Location',[363 356 1674 1075])"
+		  "'Measurements',true,'Version','2016b')),'Version','2017a','Location',[363 356 1674 1075])"
 		  NumInputPorts		  "5"
 		}
 		Block {
@@ -9618,7 +9507,7 @@ Model {
 		  "n'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNa"
 		  "mes',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),extmg"
 		  "r.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('"
-		  "Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[66 106 1377 825])"
+		  "Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 106 1377 825])"
 		  NumInputPorts		  "5"
 		}
 		Block {
@@ -9708,7 +9597,7 @@ Model {
 		  "le','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedCha"
 		  "nnelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1])"
 		  ",extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurement"
-		  "s',true,'Version','2017b')),'Version','2017b','Location',[66 78 1367 767])"
+		  "s',true,'Version','2017b')),'Version','2017a','Location',[66 78 1367 767])"
 		  NumInputPorts		  "5"
 		}
 		Block {
@@ -9798,7 +9687,7 @@ Model {
 		  "','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDe"
 		  "finedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions"
 		  "',[6 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false),extmgr.Configuration('Tools','Mea"
-		  "surements',true,'Version','2017b')),'Version','2017b','Location',[66 106 1367 795])"
+		  "surements',true,'Version','2017b')),'Version','2017a','Location',[66 106 1367 795])"
 		  NumInputPorts		  "5"
 		}
 		Block {
@@ -9890,7 +9779,7 @@ Model {
 		  "e','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChan"
 		  "nelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),"
 		  "extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configurat"
-		  "ion('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[351 265 1632 866])"
+		  "ion('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[351 265 1632 866])"
 		  NumInputPorts		  "5"
 		}
 		Block {
@@ -9982,7 +9871,7 @@ Model {
 		  "truct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',"
 		  "{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),extmgr.Con"
 		  "figuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools"
-		  "','Measurements',true,'Version','2016b')),'Version','2017b','Location',[515 467 1806 1126])"
+		  "','Measurements',true,'Version','2016b')),'Version','2017a','Location',[515 467 1806 1126])"
 		  NumInputPorts		  "5"
 		}
 		Block {
@@ -10072,7 +9961,7 @@ Model {
 		  "'Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefi"
 		  "nedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',"
 		  "[6 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false),extmgr.Configuration('Tools','Measu"
-		  "rements',true,'Version','2017b')),'Version','2017b','Location',[66 78 1367 767])"
+		  "rements',true,'Version','2017b')),'Version','2017a','Location',[66 78 1367 767])"
 		  NumInputPorts		  "5"
 		}
 		Line {
@@ -11245,7 +11134,7 @@ Model {
 		TiledPageScale		1
 		ShowPageBoundaries	off
 		ZoomFactor		"100"
-		SIDHighWatermark	"79"
+		SIDHighWatermark	"85"
 		Block {
 		  BlockType		  Inport
 		  Name			  "pos_vel_acc_CoM_des"
@@ -11365,20 +11254,20 @@ Model {
 		Block {
 		  BlockType		  Demux
 		  Name			  " Demux "
-		  SID			  "4438::78"
+		  SID			  "4438::84"
 		  Ports			  [1, 1]
 		  Position		  [270, 230, 320, 270]
-		  ZOrder		  68
+		  ZOrder		  74
 		  Outputs		  "1"
 		}
 		Block {
 		  BlockType		  S-Function
 		  Name			  " SFunction "
-		  SID			  "4438::77"
-		  Tag			  "Stateflow S-Function torqueWalkingMPC 6"
+		  SID			  "4438::83"
+		  Tag			  "Stateflow S-Function torqueWalkingMPC_R2016b 6"
 		  Ports			  [13, 2]
 		  Position		  [180, 90, 230, 370]
-		  ZOrder		  67
+		  ZOrder		  73
 		  FunctionName		  "sf_sfun"
 		  Parameters		  "Sat"
 		  PortCounts		  "[13 2]"
@@ -11388,16 +11277,14 @@ Model {
 		  Port {
 		    PortNumber		    2
 		    Name		    "acc_task_star"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
 		  BlockType		  Terminator
 		  Name			  " Terminator "
-		  SID			  "4438::79"
+		  SID			  "4438::85"
 		  Position		  [460, 241, 480, 259]
-		  ZOrder		  69
+		  ZOrder		  75
 		}
 		Block {
 		  BlockType		  Outport
@@ -11408,91 +11295,91 @@ Model {
 		  IconDisplay		  "Port number"
 		}
 		Line {
-		  ZOrder		  97
+		  ZOrder		  129
 		  SrcBlock		  "pos_vel_acc_CoM_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  98
+		  ZOrder		  130
 		  SrcBlock		  "pose_vel_acc_LFoot_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  2
 		}
 		Line {
-		  ZOrder		  99
+		  ZOrder		  131
 		  SrcBlock		  "pose_vel_acc_RFoot_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  3
 		}
 		Line {
-		  ZOrder		  100
+		  ZOrder		  132
 		  SrcBlock		  "orient_vel_acc_rot_task_des"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  4
 		}
 		Line {
-		  ZOrder		  101
+		  ZOrder		  133
 		  SrcBlock		  "pos_vel_CoM"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  5
 		}
 		Line {
-		  ZOrder		  102
+		  ZOrder		  134
 		  SrcBlock		  "pose_vel_LFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  6
 		}
 		Line {
-		  ZOrder		  103
+		  ZOrder		  135
 		  SrcBlock		  "pose_vel_RFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  7
 		}
 		Line {
-		  ZOrder		  104
+		  ZOrder		  136
 		  SrcBlock		  "orient_vel_rot_task"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  8
 		}
 		Line {
-		  ZOrder		  105
+		  ZOrder		  137
 		  SrcBlock		  "Kp_Kd_CoM"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  9
 		}
 		Line {
-		  ZOrder		  106
+		  ZOrder		  138
 		  SrcBlock		  "Kp_Kd_LFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  10
 		}
 		Line {
-		  ZOrder		  107
+		  ZOrder		  139
 		  SrcBlock		  "Kp_Kd_RFoot"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  11
 		}
 		Line {
-		  ZOrder		  108
+		  ZOrder		  140
 		  SrcBlock		  "Kp_Kd_rot_task"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
 		  DstPort		  12
 		}
 		Line {
-		  ZOrder		  109
+		  ZOrder		  141
 		  SrcBlock		  "feetInContact"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
@@ -11500,7 +11387,7 @@ Model {
 		}
 		Line {
 		  Name			  "acc_task_star"
-		  ZOrder		  110
+		  ZOrder		  142
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  2
@@ -11508,14 +11395,14 @@ Model {
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  111
+		  ZOrder		  143
 		  SrcBlock		  " Demux "
 		  SrcPort		  1
 		  DstBlock		  " Terminator "
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  112
+		  ZOrder		  144
 		  SrcBlock		  " SFunction "
 		  SrcPort		  1
 		  DstBlock		  " Demux "
@@ -11637,7 +11524,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "94"
+		    SIDHighWatermark	    "100"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "vel_CoM"
@@ -11712,20 +11599,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4447::93"
+		    SID			    "4447::99"
 		    Ports		    [1, 1]
 		    Position		    [270, 280, 320, 320]
-		    ZOrder		    84
+		    ZOrder		    90
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4447::92"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 7"
+		    SID			    "4447::98"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 7"
 		    Ports		    [8, 5]
 		    Position		    [180, 100, 230, 280]
-		    ZOrder		    83
+		    ZOrder		    89
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[8 5]"
 		    SFunctionDeploymentMode off
@@ -11734,34 +11621,26 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "pos_vel_CoM"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "pose_vel_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "pose_vel_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    5
 		    Name		    "orient_vel_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4447::94"
+		    SID			    "4447::100"
 		    Position		    [460, 291, 480, 309]
-		    ZOrder		    85
+		    ZOrder		    91
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -11799,56 +11678,56 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    85
+		    ZOrder		    113
 		    SrcBlock		    "vel_CoM"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    86
+		    ZOrder		    114
 		    SrcBlock		    "vel_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    87
+		    ZOrder		    115
 		    SrcBlock		    "vel_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    88
+		    ZOrder		    116
 		    SrcBlock		    "vel_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    89
+		    ZOrder		    117
 		    SrcBlock		    "w_H_CoM"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    90
+		    ZOrder		    118
 		    SrcBlock		    "w_H_l_sole"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    6
 		    }
 		    Line {
-		    ZOrder		    91
+		    ZOrder		    119
 		    SrcBlock		    "w_H_r_sole"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    7
 		    }
 		    Line {
-		    ZOrder		    92
+		    ZOrder		    120
 		    SrcBlock		    "w_H_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -11856,7 +11735,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pos_vel_CoM"
-		    ZOrder		    93
+		    ZOrder		    121
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -11865,7 +11744,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pose_vel_LFoot"
-		    ZOrder		    94
+		    ZOrder		    122
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -11874,7 +11753,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "pose_vel_RFoot"
-		    ZOrder		    95
+		    ZOrder		    123
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -11883,7 +11762,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "orient_vel_rot_task"
-		    ZOrder		    96
+		    ZOrder		    124
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    5
@@ -11891,14 +11770,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    97
+		    ZOrder		    125
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    98
+		    ZOrder		    126
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    Points		    [20, 0]
@@ -13232,7 +13111,7 @@ Model {
       Variant		      off
       System {
 	Name			"Robot State and References"
-	Location		[65, 24, 1920, 1080]
+	Location		[61, 35, 1916, 1091]
 	Open			off
 	ModelBrowserVisibility	off
 	ModelBrowserWidth	200
@@ -13244,7 +13123,7 @@ Model {
 	TiledPaperMargins	[0.500000, 0.500000, 0.500000, 0.500000]
 	TiledPageScale		1
 	ShowPageBoundaries	off
-	ZoomFactor		"170"
+	ZoomFactor		"100"
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "Gain Scheduling"
@@ -13317,7 +13196,7 @@ Model {
 		TiledPageScale		1
 		ShowPageBoundaries	off
 		ZoomFactor		"100"
-		SIDHighWatermark	"72"
+		SIDHighWatermark	"78"
 		Block {
 		  BlockType		  Inport
 		  Name			  "state"
@@ -13329,20 +13208,20 @@ Model {
 		Block {
 		  BlockType		  Demux
 		  Name			  " Demux "
-		  SID			  "4534::71"
+		  SID			  "4534::77"
 		  Ports			  [1, 1]
 		  Position		  [270, 530, 320, 570]
-		  ZOrder		  61
+		  ZOrder		  67
 		  Outputs		  "1"
 		}
 		Block {
 		  BlockType		  S-Function
 		  Name			  " SFunction "
-		  SID			  "4534::70"
-		  Tag			  "Stateflow S-Function torqueWalkingMPC 8"
+		  SID			  "4534::76"
+		  Tag			  "Stateflow S-Function torqueWalkingMPC_R2016b 8"
 		  Ports			  [1, 12]
 		  Position		  [180, 95, 230, 355]
-		  ZOrder		  60
+		  ZOrder		  66
 		  FunctionName		  "sf_sfun"
 		  Parameters		  "Config,Gains"
 		  PortCounts		  "[1 12]"
@@ -13352,76 +13231,54 @@ Model {
 		  Port {
 		    PortNumber		    2
 		    Name		    "Kp_CoM"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    3
 		    Name		    "Kd_CoM"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    4
 		    Name		    "Kp_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    5
 		    Name		    "Kd_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    6
 		    Name		    "Kp_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    7
 		    Name		    "Kd_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    8
 		    Name		    "Kp_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    9
 		    Name		    "Kd_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    10
 		    Name		    "impedances"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    11
 		    Name		    "dampings"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		  Port {
 		    PortNumber		    12
 		    Name		    "smoothingTimeGains"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		  }
 		}
 		Block {
 		  BlockType		  Terminator
 		  Name			  " Terminator "
-		  SID			  "4534::72"
+		  SID			  "4534::78"
 		  Position		  [460, 541, 480, 559]
-		  ZOrder		  62
+		  ZOrder		  68
 		}
 		Block {
 		  BlockType		  Outport
@@ -13522,7 +13379,7 @@ Model {
 		  IconDisplay		  "Port number"
 		}
 		Line {
-		  ZOrder		  127
+		  ZOrder		  155
 		  SrcBlock		  "state"
 		  SrcPort		  1
 		  DstBlock		  " SFunction "
@@ -13530,7 +13387,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kp_CoM"
-		  ZOrder		  128
+		  ZOrder		  156
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  2
@@ -13539,7 +13396,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kd_CoM"
-		  ZOrder		  129
+		  ZOrder		  157
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  3
@@ -13548,7 +13405,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kp_LFoot"
-		  ZOrder		  130
+		  ZOrder		  158
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  4
@@ -13557,7 +13414,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kd_LFoot"
-		  ZOrder		  131
+		  ZOrder		  159
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  5
@@ -13566,7 +13423,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kp_RFoot"
-		  ZOrder		  132
+		  ZOrder		  160
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  6
@@ -13575,7 +13432,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kd_RFoot"
-		  ZOrder		  133
+		  ZOrder		  161
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  7
@@ -13584,7 +13441,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kp_rot_task"
-		  ZOrder		  134
+		  ZOrder		  162
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  8
@@ -13593,7 +13450,7 @@ Model {
 		}
 		Line {
 		  Name			  "Kd_rot_task"
-		  ZOrder		  135
+		  ZOrder		  163
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  9
@@ -13602,7 +13459,7 @@ Model {
 		}
 		Line {
 		  Name			  "impedances"
-		  ZOrder		  136
+		  ZOrder		  164
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  10
@@ -13611,7 +13468,7 @@ Model {
 		}
 		Line {
 		  Name			  "dampings"
-		  ZOrder		  137
+		  ZOrder		  165
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  11
@@ -13620,7 +13477,7 @@ Model {
 		}
 		Line {
 		  Name			  "smoothingTimeGains"
-		  ZOrder		  138
+		  ZOrder		  166
 		  Labels		  [0, 0]
 		  SrcBlock		  " SFunction "
 		  SrcPort		  12
@@ -13628,14 +13485,14 @@ Model {
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  139
+		  ZOrder		  167
 		  SrcBlock		  " Demux "
 		  SrcPort		  1
 		  DstBlock		  " Terminator "
 		  DstPort		  1
 		}
 		Line {
-		  ZOrder		  140
+		  ZOrder		  168
 		  SrcBlock		  " SFunction "
 		  SrcPort		  1
 		  DstBlock		  " Demux "
@@ -14138,7 +13995,7 @@ Model {
 	  Variant		  off
 	  System {
 	    Name		    "Smooth References "
-	    Location		    [65, 24, 1920, 1080]
+	    Location		    [53, 27, 1366, 768]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -14150,7 +14007,7 @@ Model {
 	    TiledPaperMargins	    [0.500000, 0.500000, 0.500000, 0.500000]
 	    TiledPageScale	    1
 	    ShowPageBoundaries	    off
-	    ZoomFactor		    "181"
+	    ZoomFactor		    "121"
 	    Block {
 	      BlockType		      Inport
 	      Name		      "state"
@@ -14163,7 +14020,7 @@ Model {
 	      BlockType		      Inport
 	      Name		      "references_CoM"
 	      SID		      "5242"
-	      Position		      [-510, 295, -480, 305]
+	      Position		      [-510, 285, -480, 295]
 	      ZOrder		      857
 	      Port		      "2"
 	      IconDisplay	      "Port number"
@@ -14172,7 +14029,7 @@ Model {
 	      BlockType		      Inport
 	      Name		      "references_LFoot"
 	      SID		      "5243"
-	      Position		      [-510, 320, -480, 330]
+	      Position		      [-510, 315, -480, 325]
 	      ZOrder		      858
 	      Port		      "3"
 	      IconDisplay	      "Port number"
@@ -14199,7 +14056,7 @@ Model {
 	      BlockType		      Inport
 	      Name		      "references_s"
 	      SID		      "5246"
-	      Position		      [-510, 370, -480, 380]
+	      Position		      [-510, 375, -480, 385]
 	      ZOrder		      861
 	      Port		      "6"
 	      IconDisplay	      "Port number"
@@ -14839,7 +14696,7 @@ Model {
 	      Name		      "Selector1"
 	      SID		      "4652"
 	      Ports		      [1, 1]
-	      Position		      [-310, 293, -280, 307]
+	      Position		      [-310, 283, -280, 297]
 	      ZOrder		      870
 	      NumberOfDimensions      "2"
 	      InputPortWidth	      "3"
@@ -14852,7 +14709,7 @@ Model {
 	      Name		      "Selector2"
 	      SID		      "4653"
 	      Ports		      [1, 1]
-	      Position		      [-310, 318, -280, 332]
+	      Position		      [-310, 313, -280, 327]
 	      ZOrder		      871
 	      NumberOfDimensions      "2"
 	      InputPortWidth	      "3"
@@ -14891,7 +14748,7 @@ Model {
 	      Name		      "Selector7"
 	      SID		      "5265"
 	      Ports		      [1, 1]
-	      Position		      [-310, 368, -280, 382]
+	      Position		      [-310, 373, -280, 387]
 	      ZOrder		      873
 	      NumberOfDimensions      "2"
 	      InputPortWidth	      "ROBOT_DOF"
@@ -15350,7 +15207,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "80"
+		    SIDHighWatermark	    "86"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "w_R_LFoot_des"
@@ -15443,20 +15300,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4570::79"
+		    SID			    "4570::85"
 		    Ports		    [1, 1]
 		    Position		    [270, 245, 320, 285]
-		    ZOrder		    69
+		    ZOrder		    75
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4570::78"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 9"
+		    SID			    "4570::84"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 9"
 		    Ports		    [10, 4]
 		    Position		    [180, 100, 230, 320]
-		    ZOrder		    68
+		    ZOrder		    74
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Config"
 		    PortCounts		    "[10 4]"
@@ -15466,28 +15323,22 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "omegaDot_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "omegaDot_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "omegaDot_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4570::80"
+		    SID			    "4570::86"
 		    Position		    [460, 256, 480, 274]
-		    ZOrder		    70
+		    ZOrder		    76
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -15516,70 +15367,70 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    120
+		    ZOrder		    150
 		    SrcBlock		    "w_R_LFoot_des"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    121
+		    ZOrder		    151
 		    SrcBlock		    "w_R_RFoot_des"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    122
+		    ZOrder		    152
 		    SrcBlock		    "w_R_rot_task_des"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    123
+		    ZOrder		    153
 		    SrcBlock		    "w_R_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    124
+		    ZOrder		    154
 		    SrcBlock		    "w_R_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    125
+		    ZOrder		    155
 		    SrcBlock		    "w_R_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    6
 		    }
 		    Line {
-		    ZOrder		    126
+		    ZOrder		    156
 		    SrcBlock		    "state"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    7
 		    }
 		    Line {
-		    ZOrder		    127
+		    ZOrder		    157
 		    SrcBlock		    "omega_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    8
 		    }
 		    Line {
-		    ZOrder		    128
+		    ZOrder		    158
 		    SrcBlock		    "omega_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    9
 		    }
 		    Line {
-		    ZOrder		    129
+		    ZOrder		    159
 		    SrcBlock		    "omega_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -15587,7 +15438,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "omegaDot_LFoot"
-		    ZOrder		    130
+		    ZOrder		    160
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -15596,7 +15447,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "omegaDot_RFoot"
-		    ZOrder		    131
+		    ZOrder		    161
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -15605,7 +15456,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "omegaDot_rot_task"
-		    ZOrder		    132
+		    ZOrder		    162
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -15613,14 +15464,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    133
+		    ZOrder		    163
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    134
+		    ZOrder		    164
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -16194,7 +16045,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "82"
+		    SIDHighWatermark	    "88"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "omega_LFoot"
@@ -16251,20 +16102,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4571::81"
+		    SID			    "4571::87"
 		    Ports		    [1, 1]
 		    Position		    [270, 245, 320, 285]
-		    ZOrder		    71
+		    ZOrder		    77
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4571::80"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 12"
+		    SID			    "4571::86"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 12"
 		    Ports		    [6, 4]
 		    Position		    [180, 102, 230, 243]
-		    ZOrder		    70
+		    ZOrder		    76
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[6 4]"
 		    SFunctionDeploymentMode off
@@ -16273,28 +16124,22 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "RDot_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "RDot_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "RDot_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4571::82"
+		    SID			    "4571::88"
 		    Position		    [460, 256, 480, 274]
-		    ZOrder		    72
+		    ZOrder		    78
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -16323,42 +16168,42 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    67
+		    ZOrder		    89
 		    SrcBlock		    "omega_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    68
+		    ZOrder		    90
 		    SrcBlock		    "omega_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    69
+		    ZOrder		    91
 		    SrcBlock		    "omega_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    70
+		    ZOrder		    92
 		    SrcBlock		    "w_R_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    71
+		    ZOrder		    93
 		    SrcBlock		    "w_R_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    72
+		    ZOrder		    94
 		    SrcBlock		    "w_R_rot_task"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -16366,7 +16211,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "RDot_LFoot"
-		    ZOrder		    73
+		    ZOrder		    95
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -16375,7 +16220,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "RDot_RFoot"
-		    ZOrder		    74
+		    ZOrder		    96
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -16384,7 +16229,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "RDot_rot_task"
-		    ZOrder		    75
+		    ZOrder		    97
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -16392,14 +16237,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    76
+		    ZOrder		    98
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    77
+		    ZOrder		    99
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    Points		    [20, 0]
@@ -16887,13 +16732,13 @@ Model {
 	      Name		      "Smooth Reference Positions"
 	      SID		      "4624"
 	      Ports		      [5, 4]
-	      Position		      [-220, 281, -10, 419]
+	      Position		      [-220, 279, -10, 421]
 	      ZOrder		      867
 	      RequestExecContextInheritance off
 	      Variant		      off
 	      System {
 		Name			"Smooth Reference Positions"
-		Location		[65, 24, 1920, 1080]
+		Location		[61, 35, 1916, 1091]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -16905,7 +16750,7 @@ Model {
 		TiledPaperMargins	[0.500000, 0.500000, 0.500000, 0.500000]
 		TiledPageScale		1
 		ShowPageBoundaries	off
-		ZoomFactor		"202"
+		ZoomFactor		"201"
 		Block {
 		  BlockType		  Inport
 		  Name			  "pos_CoM_des"
@@ -16918,8 +16763,8 @@ Model {
 		  BlockType		  Inport
 		  Name			  "pos_LFoot_des"
 		  SID			  "4626"
-		  Position		  [150, 315, 180, 325]
-		  ZOrder		  757
+		  Position		  [150, 235, 180, 245]
+		  ZOrder		  777
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
@@ -16927,8 +16772,8 @@ Model {
 		  BlockType		  Inport
 		  Name			  "pos_RFoot_des"
 		  SID			  "4627"
-		  Position		  [150, 395, 180, 405]
-		  ZOrder		  758
+		  Position		  [150, 315, 180, 325]
+		  ZOrder		  778
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
@@ -16936,8 +16781,8 @@ Model {
 		  BlockType		  Inport
 		  Name			  "s_des"
 		  SID			  "4628"
-		  Position		  [150, 235, 180, 245]
-		  ZOrder		  759
+		  Position		  [150, 395, 180, 405]
+		  ZOrder		  770
 		  Port			  "4"
 		  IconDisplay		  "Port number"
 		}
@@ -16978,7 +16823,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "48"
+		    SIDHighWatermark	    "54"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "state"
@@ -16990,20 +16835,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "5315::47"
+		    SID			    "5315::53"
 		    Ports		    [1, 1]
 		    Position		    [270, 280, 320, 320]
-		    ZOrder		    38
+		    ZOrder		    44
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "5315::46"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 17"
+		    SID			    "5315::52"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 17"
 		    Ports		    [1, 5]
 		    Position		    [180, 100, 230, 220]
-		    ZOrder		    37
+		    ZOrder		    43
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Config"
 		    PortCounts		    "[1 5]"
@@ -17013,34 +16858,26 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "smoothingTime_CoM"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "smoothingTime_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "smoothingTime_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    5
 		    Name		    "smoothingTime_joints"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "5315::48"
+		    SID			    "5315::54"
 		    Position		    [460, 291, 480, 309]
-		    ZOrder		    39
+		    ZOrder		    45
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -17078,7 +16915,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    145
+		    ZOrder		    159
 		    SrcBlock		    "state"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -17086,7 +16923,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "smoothingTime_CoM"
-		    ZOrder		    146
+		    ZOrder		    160
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -17096,7 +16933,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "smoothingTime_LFoot"
-		    ZOrder		    147
+		    ZOrder		    161
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -17105,7 +16942,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "smoothingTime_RFoot"
-		    ZOrder		    148
+		    ZOrder		    162
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -17114,7 +16951,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "smoothingTime_joints"
-		    ZOrder		    149
+		    ZOrder		    163
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    5
@@ -17122,14 +16959,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    150
+		    ZOrder		    164
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    151
+		    ZOrder		    165
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -17142,8 +16979,8 @@ Model {
 		  Name			  "Matrix\nConcatenate1"
 		  SID			  "4629"
 		  Ports			  [3, 1]
-		  Position		  [450, 222, 575, 278]
-		  ZOrder		  693
+		  Position		  [450, 382, 575, 438]
+		  ZOrder		  769
 		  NamePlacement		  "alternate"
 		  NumInputs		  "3"
 		  Mode			  "Multidimensional array"
@@ -17154,8 +16991,8 @@ Model {
 		  Name			  "Matrix\nConcatenate2"
 		  SID			  "4630"
 		  Ports			  [4, 1]
-		  Position		  [450, 383, 575, 457]
-		  ZOrder		  711
+		  Position		  [450, 303, 575, 377]
+		  ZOrder		  775
 		  NamePlacement		  "alternate"
 		  NumInputs		  "4"
 		  Mode			  "Multidimensional array"
@@ -17166,8 +17003,8 @@ Model {
 		  Name			  "Matrix\nConcatenate3"
 		  SID			  "4631"
 		  Ports			  [4, 1]
-		  Position		  [450, 301, 575, 379]
-		  ZOrder		  713
+		  Position		  [450, 221, 575, 299]
+		  ZOrder		  776
 		  NamePlacement		  "alternate"
 		  NumInputs		  "4"
 		  Mode			  "Multidimensional array"
@@ -17208,8 +17045,8 @@ Model {
 		  Name			  "Minimum Jerk Trajectory Generator1"
 		  SID			  "4634"
 		  Ports			  [2, 3]
-		  Position		  [235, 223, 390, 277]
-		  ZOrder		  692
+		  Position		  [235, 383, 390, 437]
+		  ZOrder		  768
 		  LibraryVersion	  "1.383"
 		  SourceBlock		  "WBToolboxLibrary/Utilities/Minimum Jerk Trajectory Generator"
 		  SourceType		  "Minimum Jerk Trajectory Generator"
@@ -17226,8 +17063,8 @@ Model {
 		  Name			  "Minimum Jerk Trajectory Generator2"
 		  SID			  "4635"
 		  Ports			  [2, 3]
-		  Position		  [235, 303, 390, 357]
-		  ZOrder		  696
+		  Position		  [235, 223, 390, 277]
+		  ZOrder		  772
 		  LibraryVersion	  "1.383"
 		  SourceBlock		  "WBToolboxLibrary/Utilities/Minimum Jerk Trajectory Generator"
 		  SourceType		  "Minimum Jerk Trajectory Generator"
@@ -17244,8 +17081,8 @@ Model {
 		  Name			  "Minimum Jerk Trajectory Generator3"
 		  SID			  "4636"
 		  Ports			  [2, 3]
-		  Position		  [235, 383, 390, 437]
-		  ZOrder		  697
+		  Position		  [235, 303, 390, 357]
+		  ZOrder		  773
 		  LibraryVersion	  "1.383"
 		  SourceBlock		  "WBToolboxLibrary/Utilities/Minimum Jerk Trajectory Generator"
 		  SourceType		  "Minimum Jerk Trajectory Generator"
@@ -17261,8 +17098,8 @@ Model {
 		  BlockType		  Constant
 		  Name			  "Settling time1"
 		  SID			  "4637"
-		  Position		  [285, 441, 345, 459]
-		  ZOrder		  710
+		  Position		  [285, 466, 345, 484]
+		  ZOrder		  774
 		  Value			  "zeros(3,2)"
 		}
 		Block {
@@ -17277,8 +17114,8 @@ Model {
 		  BlockType		  Outport
 		  Name			  "smooth_pos_vel_acc_LFoot"
 		  SID			  "4641"
-		  Position		  [675, 333, 705, 347]
-		  ZOrder		  764
+		  Position		  [675, 253, 705, 267]
+		  ZOrder		  779
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
@@ -17286,8 +17123,8 @@ Model {
 		  BlockType		  Outport
 		  Name			  "smooth_pos_vel_acc_RFoot"
 		  SID			  "4642"
-		  Position		  [675, 413, 705, 427]
-		  ZOrder		  765
+		  Position		  [675, 333, 705, 347]
+		  ZOrder		  780
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
@@ -17295,72 +17132,16 @@ Model {
 		  BlockType		  Outport
 		  Name			  "smooth_references_s"
 		  SID			  "4640"
-		  Position		  [675, 243, 705, 257]
-		  ZOrder		  761
+		  Position		  [675, 403, 705, 417]
+		  ZOrder		  771
 		  Port			  "4"
 		  IconDisplay		  "Port number"
-		}
-		Line {
-		  ZOrder		  1
-		  SrcBlock		  "Minimum Jerk Trajectory Generator2"
-		  SrcPort		  2
-		  DstBlock		  "Matrix\nConcatenate3"
-		  DstPort		  2
-		}
-		Line {
-		  ZOrder		  2
-		  SrcBlock		  "pos_LFoot_des"
-		  SrcPort		  1
-		  DstBlock		  "Minimum Jerk Trajectory Generator2"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  3
-		  SrcBlock		  "pos_RFoot_des"
-		  SrcPort		  1
-		  DstBlock		  "Minimum Jerk Trajectory Generator3"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  4
-		  SrcBlock		  "Minimum Jerk Trajectory Generator2"
-		  SrcPort		  3
-		  DstBlock		  "Matrix\nConcatenate3"
-		  DstPort		  3
-		}
-		Line {
-		  ZOrder		  5
-		  SrcBlock		  "Minimum Jerk Trajectory Generator2"
-		  SrcPort		  1
-		  DstBlock		  "Matrix\nConcatenate3"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  6
-		  SrcBlock		  "Minimum Jerk Trajectory Generator1"
-		  SrcPort		  3
-		  DstBlock		  "Matrix\nConcatenate1"
-		  DstPort		  3
-		}
-		Line {
-		  ZOrder		  7
-		  SrcBlock		  "Matrix\nConcatenate1"
-		  SrcPort		  1
-		  DstBlock		  "smooth_references_s"
-		  DstPort		  1
 		}
 		Line {
 		  ZOrder		  8
 		  SrcBlock		  "Matrix\nConcatenate4"
 		  SrcPort		  1
 		  DstBlock		  "smooth_references_CoM"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  9
-		  SrcBlock		  "Minimum Jerk Trajectory Generator1"
-		  SrcPort		  1
-		  DstBlock		  "Matrix\nConcatenate1"
 		  DstPort		  1
 		}
 		Line {
@@ -17385,76 +17166,10 @@ Model {
 		  DstPort		  2
 		}
 		Line {
-		  ZOrder		  13
-		  SrcBlock		  "Minimum Jerk Trajectory Generator1"
-		  SrcPort		  2
-		  DstBlock		  "Matrix\nConcatenate1"
-		  DstPort		  2
-		}
-		Line {
-		  ZOrder		  14
-		  SrcBlock		  "Minimum Jerk Trajectory Generator3"
-		  SrcPort		  3
-		  DstBlock		  "Matrix\nConcatenate2"
-		  DstPort		  3
-		}
-		Line {
-		  ZOrder		  15
-		  SrcBlock		  "Matrix\nConcatenate3"
-		  SrcPort		  1
-		  DstBlock		  "smooth_pos_vel_acc_LFoot"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  16
-		  SrcBlock		  "Matrix\nConcatenate2"
-		  SrcPort		  1
-		  DstBlock		  "smooth_pos_vel_acc_RFoot"
-		  DstPort		  1
-		}
-		Line {
 		  ZOrder		  17
 		  SrcBlock		  "Minimum Jerk Trajectory Generator"
 		  SrcPort		  1
 		  DstBlock		  "Matrix\nConcatenate4"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  18
-		  SrcBlock		  "Minimum Jerk Trajectory Generator3"
-		  SrcPort		  2
-		  DstBlock		  "Matrix\nConcatenate2"
-		  DstPort		  2
-		}
-		Line {
-		  ZOrder		  19
-		  SrcBlock		  "s_des"
-		  SrcPort		  1
-		  DstBlock		  "Minimum Jerk Trajectory Generator1"
-		  DstPort		  1
-		}
-		Line {
-		  ZOrder		  20
-		  SrcBlock		  "Settling time1"
-		  SrcPort		  1
-		  Points		  [63, 0]
-		  Branch {
-		    ZOrder		    21
-		    DstBlock		    "Matrix\nConcatenate2"
-		    DstPort		    4
-		  }
-		  Branch {
-		    ZOrder		    22
-		    Points		    [0, -80]
-		    DstBlock		    "Matrix\nConcatenate3"
-		    DstPort		    4
-		  }
-		}
-		Line {
-		  ZOrder		  30
-		  SrcBlock		  "Minimum Jerk Trajectory Generator3"
-		  SrcPort		  1
-		  DstBlock		  "Matrix\nConcatenate2"
 		  DstPort		  1
 		}
 		Line {
@@ -17472,25 +17187,147 @@ Model {
 		  DstPort		  2
 		}
 		Line {
-		  ZOrder		  33
-		  SrcBlock		  "Configure Settling Times"
+		  ZOrder		  48
+		  SrcBlock		  "Minimum Jerk Trajectory Generator1"
+		  SrcPort		  3
+		  DstBlock		  "Matrix\nConcatenate1"
+		  DstPort		  3
+		}
+		Line {
+		  ZOrder		  49
+		  SrcBlock		  "Minimum Jerk Trajectory Generator1"
 		  SrcPort		  2
+		  DstBlock		  "Matrix\nConcatenate1"
+		  DstPort		  2
+		}
+		Line {
+		  ZOrder		  71
+		  SrcBlock		  "Configure Settling Times"
+		  SrcPort		  4
 		  DstBlock		  "Minimum Jerk Trajectory Generator1"
 		  DstPort		  2
 		}
 		Line {
-		  ZOrder		  34
-		  SrcBlock		  "Configure Settling Times"
+		  ZOrder		  51
+		  SrcBlock		  "Minimum Jerk Trajectory Generator1"
+		  SrcPort		  1
+		  DstBlock		  "Matrix\nConcatenate1"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  52
+		  SrcBlock		  "s_des"
+		  SrcPort		  1
+		  DstBlock		  "Minimum Jerk Trajectory Generator1"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  53
+		  SrcBlock		  "Matrix\nConcatenate1"
+		  SrcPort		  1
+		  DstBlock		  "smooth_references_s"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  54
+		  SrcBlock		  "pos_LFoot_des"
+		  SrcPort		  1
+		  DstBlock		  "Minimum Jerk Trajectory Generator2"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  55
+		  SrcBlock		  "Minimum Jerk Trajectory Generator2"
+		  SrcPort		  2
+		  DstBlock		  "Matrix\nConcatenate3"
+		  DstPort		  2
+		}
+		Line {
+		  ZOrder		  56
+		  SrcBlock		  "Minimum Jerk Trajectory Generator2"
+		  SrcPort		  1
+		  DstBlock		  "Matrix\nConcatenate3"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  57
+		  SrcBlock		  "Minimum Jerk Trajectory Generator3"
 		  SrcPort		  3
+		  DstBlock		  "Matrix\nConcatenate2"
+		  DstPort		  3
+		}
+		Line {
+		  ZOrder		  58
+		  SrcBlock		  "Minimum Jerk Trajectory Generator2"
+		  SrcPort		  3
+		  DstBlock		  "Matrix\nConcatenate3"
+		  DstPort		  3
+		}
+		Line {
+		  ZOrder		  69
+		  SrcBlock		  "Configure Settling Times"
+		  SrcPort		  2
 		  DstBlock		  "Minimum Jerk Trajectory Generator2"
 		  DstPort		  2
 		}
 		Line {
-		  ZOrder		  35
+		  ZOrder		  60
+		  SrcBlock		  "Minimum Jerk Trajectory Generator3"
+		  SrcPort		  1
+		  DstBlock		  "Matrix\nConcatenate2"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  61
+		  SrcBlock		  "pos_RFoot_des"
+		  SrcPort		  1
+		  DstBlock		  "Minimum Jerk Trajectory Generator3"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  62
+		  SrcBlock		  "Matrix\nConcatenate3"
+		  SrcPort		  1
+		  DstBlock		  "smooth_pos_vel_acc_LFoot"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  63
+		  SrcBlock		  "Matrix\nConcatenate2"
+		  SrcPort		  1
+		  DstBlock		  "smooth_pos_vel_acc_RFoot"
+		  DstPort		  1
+		}
+		Line {
+		  ZOrder		  70
 		  SrcBlock		  "Configure Settling Times"
-		  SrcPort		  4
+		  SrcPort		  3
 		  DstBlock		  "Minimum Jerk Trajectory Generator3"
 		  DstPort		  2
+		}
+		Line {
+		  ZOrder		  65
+		  SrcBlock		  "Minimum Jerk Trajectory Generator3"
+		  SrcPort		  2
+		  DstBlock		  "Matrix\nConcatenate2"
+		  DstPort		  2
+		}
+		Line {
+		  ZOrder		  68
+		  SrcBlock		  "Settling time1"
+		  SrcPort		  1
+		  Points		  [63, 0; 0, -105]
+		  Branch {
+		    ZOrder		    67
+		    DstBlock		    "Matrix\nConcatenate2"
+		    DstPort		    4
+		  }
+		  Branch {
+		    ZOrder		    66
+		    Points		    [0, -80]
+		    DstBlock		    "Matrix\nConcatenate3"
+		    DstPort		    4
+		  }
 		}
 	      }
 	    }
@@ -17545,7 +17382,7 @@ Model {
 	      Points		      [130, 0]
 	      Branch {
 		ZOrder			174
-		Points			[0, 140]
+		Points			[0, 150]
 		DstBlock		"Choose Smoothed or Direct References"
 		DstPort			5
 	      }
@@ -17569,7 +17406,7 @@ Model {
 	      Points		      [108, 0]
 	      Branch {
 		ZOrder			176
-		Points			[0, 150]
+		Points			[0, 155]
 		Branch {
 		  ZOrder		  156
 		  DstBlock		  "Choose Smoothed or Direct References"
@@ -17589,7 +17426,7 @@ Model {
 	      }
 	    }
 	    Line {
-	      ZOrder		      96
+	      ZOrder		      219
 	      SrcBlock		      "Selector2"
 	      SrcPort		      1
 	      DstBlock		      "Smooth Reference Positions"
@@ -17622,7 +17459,7 @@ Model {
 	      }
 	    }
 	    Line {
-	      ZOrder		      98
+	      ZOrder		      220
 	      SrcBlock		      "Selector6"
 	      SrcPort		      1
 	      DstBlock		      "Smooth Reference Positions"
@@ -17635,7 +17472,7 @@ Model {
 	      Points		      [61, 0]
 	      Branch {
 		ZOrder			182
-		Points			[0, 170]
+		Points			[0, 165]
 		DstBlock		"Choose Smoothed or Direct References"
 		DstPort			8
 	      }
@@ -17646,7 +17483,7 @@ Model {
 	      }
 	    }
 	    Line {
-	      ZOrder		      100
+	      ZOrder		      221
 	      SrcBlock		      "Selector7"
 	      SrcPort		      1
 	      DstBlock		      "Smooth Reference Positions"
@@ -17760,7 +17597,7 @@ Model {
 	      Points		      [218, 0]
 	      Branch {
 		ZOrder			190
-		Points			[0, -285]
+		Points			[0, -275]
 		DstBlock		"Smooth Reference Positions"
 		DstPort			5
 	      }
@@ -17771,21 +17608,21 @@ Model {
 	      }
 	    }
 	    Line {
-	      ZOrder		      191
+	      ZOrder		      214
 	      SrcBlock		      "Smooth Reference Positions"
 	      SrcPort		      2
 	      DstBlock		      "Choose Smoothed or Direct References"
 	      DstPort		      2
 	    }
 	    Line {
-	      ZOrder		      192
+	      ZOrder		      215
 	      SrcBlock		      "Smooth Reference Positions"
 	      SrcPort		      3
 	      DstBlock		      "Choose Smoothed or Direct References"
 	      DstPort		      3
 	    }
 	    Line {
-	      ZOrder		      193
+	      ZOrder		      216
 	      SrcBlock		      "Smooth Reference Positions"
 	      SrcPort		      4
 	      DstBlock		      "Choose Smoothed or Direct References"
@@ -18065,8 +17902,6 @@ Model {
 		    Port {
 		    PortNumber		    1
 		    Name		    "imu_H_link"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
@@ -18085,8 +17920,6 @@ Model {
 		    Port {
 		    PortNumber		    1
 		    Name		    "link_H_root"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
@@ -18157,7 +17990,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "3737"
+		    SIDHighWatermark	    "3743"
 		    SIDPrevWatermark	    "9"
 		    Block {
 		    BlockType		    Inport
@@ -18215,20 +18048,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4716::3736"
+		    SID			    "4716::3742"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    136
+		    ZOrder		    142
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4716::3735"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 11"
+		    SID			    "4716::3741"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 11"
 		    Ports		    [6, 2]
 		    Position		    [180, 102, 230, 243]
-		    ZOrder		    135
+		    ZOrder		    141
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Config"
 		    PortCounts		    "[6 2]"
@@ -18238,16 +18071,14 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "w_H_b"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4716::3737"
+		    SID			    "4716::3743"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    137
+		    ZOrder		    143
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -18258,42 +18089,42 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    55
+		    ZOrder		    73
 		    SrcBlock		    "imu_H_link"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    56
+		    ZOrder		    74
 		    SrcBlock		    "imu_H_link_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    57
+		    ZOrder		    75
 		    SrcBlock		    "link_H_base"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    58
+		    ZOrder		    76
 		    SrcBlock		    "inertial_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    59
+		    ZOrder		    77
 		    SrcBlock		    "inertial"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    60
+		    ZOrder		    78
 		    SrcBlock		    "neck_pos"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -18301,7 +18132,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "w_H_b"
-		    ZOrder		    61
+		    ZOrder		    79
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -18309,14 +18140,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    62
+		    ZOrder		    80
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    63
+		    ZOrder		    81
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -18421,8 +18252,6 @@ Model {
 		    Port {
 		    PortNumber		    1
 		    Name		    "neck pos"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
@@ -18807,8 +18636,6 @@ Model {
 		    Port {
 		    PortNumber		    1
 		    Name		    "imu_H_link"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
@@ -18827,8 +18654,6 @@ Model {
 		    Port {
 		    PortNumber		    1
 		    Name		    "link_H_root"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
@@ -18899,7 +18724,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "3737"
+		    SIDHighWatermark	    "3743"
 		    SIDPrevWatermark	    "9"
 		    Block {
 		    BlockType		    Inport
@@ -18957,20 +18782,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "5431::3736"
+		    SID			    "5431::3742"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    136
+		    ZOrder		    142
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "5431::3735"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 13"
+		    SID			    "5431::3741"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 13"
 		    Ports		    [6, 2]
 		    Position		    [180, 102, 230, 243]
-		    ZOrder		    135
+		    ZOrder		    141
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Config"
 		    PortCounts		    "[6 2]"
@@ -18980,16 +18805,14 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "w_H_b"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "5431::3737"
+		    SID			    "5431::3743"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    137
+		    ZOrder		    143
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -19000,42 +18823,42 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    55
+		    ZOrder		    73
 		    SrcBlock		    "imu_H_link"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    56
+		    ZOrder		    74
 		    SrcBlock		    "imu_H_link_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    57
+		    ZOrder		    75
 		    SrcBlock		    "link_H_base"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    58
+		    ZOrder		    76
 		    SrcBlock		    "inertial_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    59
+		    ZOrder		    77
 		    SrcBlock		    "inertial"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    60
+		    ZOrder		    78
 		    SrcBlock		    "neck_pos"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -19043,7 +18866,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "w_H_b"
-		    ZOrder		    61
+		    ZOrder		    79
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -19051,14 +18874,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    62
+		    ZOrder		    80
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    63
+		    ZOrder		    81
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -19163,8 +18986,6 @@ Model {
 		    Port {
 		    PortNumber		    1
 		    Name		    "neck pos"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
@@ -19723,7 +19544,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "3735"
+		    SIDHighWatermark	    "3741"
 		    SIDPrevWatermark	    "9"
 		    Block {
 		    BlockType		    Inport
@@ -19736,20 +19557,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "5219::3734"
+		    SID			    "5219::3740"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    133
+		    ZOrder		    139
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "5219::3733"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 25"
+		    SID			    "5219::3739"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 25"
 		    Ports		    [1, 2]
 		    Position		    [180, 100, 230, 160]
-		    ZOrder		    132
+		    ZOrder		    138
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[1 2]"
 		    SFunctionDeploymentMode off
@@ -19758,16 +19579,14 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "w_walking_H_link"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "5219::3735"
+		    SID			    "5219::3741"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    134
+		    ZOrder		    140
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -19778,7 +19597,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    25
+		    ZOrder		    33
 		    SrcBlock		    "qt_link"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -19786,7 +19605,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "w_walking_H_link"
-		    ZOrder		    26
+		    ZOrder		    34
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -19794,14 +19613,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    27
+		    ZOrder		    35
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    28
+		    ZOrder		    36
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -19838,7 +19657,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "3735"
+		    SIDHighWatermark	    "3741"
 		    SIDPrevWatermark	    "9"
 		    Block {
 		    BlockType		    Inport
@@ -19851,20 +19670,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "5507::3734"
+		    SID			    "5507::3740"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    133
+		    ZOrder		    139
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "5507::3733"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 19"
+		    SID			    "5507::3739"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 19"
 		    Ports		    [1, 2]
 		    Position		    [180, 100, 230, 160]
-		    ZOrder		    132
+		    ZOrder		    138
 		    FunctionName	    "sf_sfun"
 		    PortCounts		    "[1 2]"
 		    SFunctionDeploymentMode off
@@ -19873,16 +19692,14 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "w_walking_H_link"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "5507::3735"
+		    SID			    "5507::3741"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    134
+		    ZOrder		    140
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -19893,7 +19710,7 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    25
+		    ZOrder		    33
 		    SrcBlock		    "qt_link"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -19901,7 +19718,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "w_walking_H_link"
-		    ZOrder		    26
+		    ZOrder		    34
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -19909,14 +19726,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    27
+		    ZOrder		    35
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    28
+		    ZOrder		    36
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -20330,7 +20147,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "3746"
+		    SIDHighWatermark	    "3752"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "J_LeftFoot"
@@ -20369,20 +20186,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4760::3745"
+		    SID			    "4760::3751"
 		    Ports		    [1, 1]
 		    Position		    [270, 230, 320, 270]
-		    ZOrder		    114
+		    ZOrder		    120
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4760::3744"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 14"
+		    SID			    "4760::3750"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 14"
 		    Ports		    [4, 2]
 		    Position		    [180, 102, 230, 203]
-		    ZOrder		    113
+		    ZOrder		    119
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Sat"
 		    PortCounts		    "[4 2]"
@@ -20392,16 +20209,14 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "nu_b"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4760::3746"
+		    SID			    "4760::3752"
 		    Position		    [460, 241, 480, 259]
-		    ZOrder		    115
+		    ZOrder		    121
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -20412,28 +20227,28 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    43
+		    ZOrder		    57
 		    SrcBlock		    "J_LeftFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    44
+		    ZOrder		    58
 		    SrcBlock		    "J_RightFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    45
+		    ZOrder		    59
 		    SrcBlock		    "feetInContact"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    46
+		    ZOrder		    60
 		    SrcBlock		    "sDot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -20441,7 +20256,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "nu_b"
-		    ZOrder		    47
+		    ZOrder		    61
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -20449,14 +20264,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    48
+		    ZOrder		    62
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    49
+		    ZOrder		    63
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -21115,7 +20930,7 @@ Model {
 		    TiledPageScale	    1
 		    ShowPageBoundaries	    off
 		    ZoomFactor		    "100"
-		    SIDHighWatermark	    "99"
+		    SIDHighWatermark	    "105"
 		    Block {
 		    BlockType		    Inport
 		    Name		    "s_0"
@@ -21262,20 +21077,20 @@ Model {
 		    Block {
 		    BlockType		    Demux
 		    Name		    " Demux "
-		    SID			    "4671::98"
+		    SID			    "4671::104"
 		    Ports		    [1, 1]
 		    Position		    [270, 425, 320, 465]
-		    ZOrder		    85
+		    ZOrder		    91
 		    Outputs		    "1"
 		    }
 		    Block {
 		    BlockType		    S-Function
 		    Name		    " SFunction "
-		    SID			    "4671::97"
-		    Tag			    "Stateflow S-Function torqueWalkingMPC 10"
+		    SID			    "4671::103"
+		    Tag			    "Stateflow S-Function torqueWalkingMPC_R2016b 10"
 		    Ports		    [16, 9]
 		    Position		    [180, 85, 230, 425]
-		    ZOrder		    84
+		    ZOrder		    90
 		    FunctionName	    "sf_sfun"
 		    Parameters		    "Config"
 		    PortCounts		    "[16 9]"
@@ -21285,58 +21100,42 @@ Model {
 		    Port {
 		    PortNumber		    2
 		    Name		    "state"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    3
 		    Name		    "references_CoM"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    4
 		    Name		    "references_LFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    5
 		    Name		    "references_RFoot"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    6
 		    Name		    "references_rot_task"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    7
 		    Name		    "feetInContact"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    8
 		    Name		    "references_s"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    Port {
 		    PortNumber		    9
 		    Name		    "w_H_b"
-		    RTWStorageClass	    "Auto"
-		    DataLoggingNameMode	    "SignalName"
 		    }
 		    }
 		    Block {
 		    BlockType		    Terminator
 		    Name		    " Terminator "
-		    SID			    "4671::99"
+		    SID			    "4671::105"
 		    Position		    [460, 436, 480, 454]
-		    ZOrder		    86
+		    ZOrder		    92
 		    }
 		    Block {
 		    BlockType		    Outport
@@ -21410,112 +21209,112 @@ Model {
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
-		    ZOrder		    859
+		    ZOrder		    911
 		    SrcBlock		    "s_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    860
+		    ZOrder		    912
 		    SrcBlock		    "w_H_CoM_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    2
 		    }
 		    Line {
-		    ZOrder		    861
+		    ZOrder		    913
 		    SrcBlock		    "w_H_LFoot_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    3
 		    }
 		    Line {
-		    ZOrder		    862
+		    ZOrder		    914
 		    SrcBlock		    "w_H_RFoot_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    4
 		    }
 		    Line {
-		    ZOrder		    863
+		    ZOrder		    915
 		    SrcBlock		    "w_H_rot_task_0"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    5
 		    }
 		    Line {
-		    ZOrder		    864
+		    ZOrder		    916
 		    SrcBlock		    "w_walking_H_LFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    6
 		    }
 		    Line {
-		    ZOrder		    865
+		    ZOrder		    917
 		    SrcBlock		    "w_walking_H_RFoot"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    7
 		    }
 		    Line {
-		    ZOrder		    866
+		    ZOrder		    918
 		    SrcBlock		    "LFoot_H_b"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    8
 		    }
 		    Line {
-		    ZOrder		    867
+		    ZOrder		    919
 		    SrcBlock		    "RFoot_H_b"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    9
 		    }
 		    Line {
-		    ZOrder		    868
+		    ZOrder		    920
 		    SrcBlock		    "w_walking_H_b"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    10
 		    }
 		    Line {
-		    ZOrder		    869
+		    ZOrder		    921
 		    SrcBlock		    "t"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    11
 		    }
 		    Line {
-		    ZOrder		    870
+		    ZOrder		    922
 		    SrcBlock		    "pos_vel_acc_CoM_des_walking"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    12
 		    }
 		    Line {
-		    ZOrder		    871
+		    ZOrder		    923
 		    SrcBlock		    "s_des_walking"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    13
 		    }
 		    Line {
-		    ZOrder		    872
+		    ZOrder		    924
 		    SrcBlock		    "feetInContact_walking"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    14
 		    }
 		    Line {
-		    ZOrder		    873
+		    ZOrder		    925
 		    SrcBlock		    "LFoot_wrench"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
 		    DstPort		    15
 		    }
 		    Line {
-		    ZOrder		    874
+		    ZOrder		    926
 		    SrcBlock		    "RFoot_wrench"
 		    SrcPort		    1
 		    DstBlock		    " SFunction "
@@ -21523,7 +21322,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "state"
-		    ZOrder		    875
+		    ZOrder		    927
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    2
@@ -21533,7 +21332,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "references_CoM"
-		    ZOrder		    876
+		    ZOrder		    928
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    3
@@ -21542,7 +21341,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "references_LFoot"
-		    ZOrder		    877
+		    ZOrder		    929
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    4
@@ -21551,7 +21350,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "references_RFoot"
-		    ZOrder		    878
+		    ZOrder		    930
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    5
@@ -21560,7 +21359,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "references_rot_task"
-		    ZOrder		    879
+		    ZOrder		    931
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    6
@@ -21569,7 +21368,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "feetInContact"
-		    ZOrder		    880
+		    ZOrder		    932
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    7
@@ -21578,7 +21377,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "references_s"
-		    ZOrder		    881
+		    ZOrder		    933
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    8
@@ -21587,7 +21386,7 @@ Model {
 		    }
 		    Line {
 		    Name		    "w_H_b"
-		    ZOrder		    882
+		    ZOrder		    934
 		    Labels		    [0, 0]
 		    SrcBlock		    " SFunction "
 		    SrcPort		    9
@@ -21595,14 +21394,14 @@ Model {
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    883
+		    ZOrder		    935
 		    SrcBlock		    " Demux "
 		    SrcPort		    1
 		    DstBlock		    " Terminator "
 		    DstPort		    1
 		    }
 		    Line {
-		    ZOrder		    884
+		    ZOrder		    936
 		    SrcBlock		    " SFunction "
 		    SrcPort		    1
 		    DstBlock		    " Demux "
@@ -23249,8 +23048,8 @@ Model {
 	  Variant		  off
 	  System {
 	    Name		    "Cartesian Tasks"
-	    Location		    [65, 24, 1920, 1080]
-	    Open		    on
+	    Location		    [61, 35, 1916, 1091]
+	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
 	    ScreenColor		    "white"
@@ -23417,7 +23216,7 @@ Model {
 	      "','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')"
 	      "}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLay"
 	      "outDimensions',[4 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale"
-	      "','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2016b','Location',[66 1"
+	      "','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 1"
 	      "06 1921 1079])"
 	      NumInputPorts	      "4"
 	    }
@@ -23489,7 +23288,7 @@ Model {
 	      "Width',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','non"
 	      "e','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placeme"
 	      "nt',1),'DisplayLayoutDimensions',[4 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,"
-	      "'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b"
+	      "'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a"
 	      "','Location',[66 78 1921 1079])"
 	      NumInputPorts	      "4"
 	    }
@@ -23539,7 +23338,7 @@ Model {
 	      "[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLi"
 	      "nes',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configurati"
 	      "on('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Me"
-	      "asurements',true,'Version','2016b')),'Version','2016b','Location',[66 171 1407 980])"
+	      "asurements',true,'Version','2016b')),'Version','2017a','Location',[66 171 1407 980])"
 	      NumInputPorts	      "2"
 	    }
 	    Block {
@@ -23588,7 +23387,7 @@ Model {
 	      "0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLin"
 	      "es',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuratio"
 	      "n('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Mea"
-	      "surements',true,'Version','2016b')),'Version','2016b','Location',[76 218 1387 937])"
+	      "surements',true,'Version','2016b')),'Version','2017a','Location',[76 218 1387 937])"
 	      NumInputPorts	      "2"
 	    }
 	    Block {
@@ -23596,7 +23395,7 @@ Model {
 	      Name		      "Norm of Rotation Error rot_task"
 	      SID		      "6222"
 	      Ports		      [2]
-	      Position		      [1665, 962, 1750, 1068]
+	      Position		      [1665, 964, 1750, 1071]
 	      ZOrder		      749
 	      ScopeSpecificationString "Simulink.scopes.TimeScopeBlockCfg('CurrentConfiguration', extmgr.ConfigurationSet(ext"
 	      "mgr.Configuration('Core','General UI',true,'FigureColor',[0.156862745098039 0.156862745098039 0.156862745098039"
@@ -23637,7 +23436,7 @@ Model {
 	      "],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0"
 	      ",'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('To"
 	      "ols','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurem"
-	      "ents',true,'Version','2016b')),'Version','2016b','Location',[66 140 1387 889])"
+	      "ents',true,'Version','2016b')),'Version','2017a','Location',[66 140 1387 889])"
 	      NumInputPorts	      "2"
 	    }
 	    Block {
@@ -23707,7 +23506,7 @@ Model {
 	      "Width',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','non"
 	      "e','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placeme"
 	      "nt',1),'DisplayLayoutDimensions',[4 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,"
-	      "'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b"
+	      "'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a"
 	      "','Location',[66 78 1921 1079])"
 	      NumInputPorts	      "4"
 	    }
@@ -24938,10 +24737,6 @@ Model {
 	      DstPort		      1
 	    }
 	    Line {
-	      FontName		      "Helvetica"
-	      FontSize		      9
-	      FontWeight	      "normal"
-	      FontAngle		      "normal"
 	      ZOrder		      68
 	      SrcBlock		      "orient_vel_Rot_task"
 	      SrcPort		      1
@@ -25142,14 +24937,10 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"force measured left foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"moments measured left foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25165,14 +24956,10 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"force measured right foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"moments measured right foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25188,14 +24975,10 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"force desired right foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"moments measured right foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25211,14 +24994,10 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"force desired left foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"moments measured left foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25239,32 +25018,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25285,32 +25054,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25331,32 +25090,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25404,7 +25153,7 @@ Model {
 	      "e','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'Us"
 	      "erDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDim"
 	      "ensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'"
-	      "),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[96 252 136"
+	      "),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[96 252 136"
 	      "7 851])"
 	      NumInputPorts	      "2"
 	    }
@@ -25438,8 +25187,6 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"force error left foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25458,8 +25205,6 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"moments measured left foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25478,8 +25223,6 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"force error right foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25498,8 +25241,6 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"moments measured right foot"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25591,7 +25332,7 @@ Model {
 	      "finedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'TimeRangeSamples','1"
 	      "4','TimeRangeFrames','14','DisplayLayoutDimensions',[6 1]),extmgr.Configuration('Tools','Plot Navigation',true,"
 	      "'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2017b'"
-	      ")),'Version','2017b','Location',[66 108 1367 797])"
+	      ")),'Version','2017a','Location',[66 108 1367 797])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -25664,7 +25405,7 @@ Model {
 	      "es',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'TimeRangeSamples','40','TimeRangeFr"
 	      "ames','40','DisplayLayoutDimensions',[4 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',fa"
 	      "lse,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2"
-	      "017b','Location',[66 78 1921 1079])"
+	      "017a','Location',[66 78 1921 1079])"
 	      NumInputPorts	      "4"
 	    }
 	    Block {
@@ -25737,7 +25478,7 @@ Model {
 	      "ChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'TimeRangeSamples','40','T"
 	      "imeRangeFrames','40','DisplayLayoutDimensions',[4 1]),extmgr.Configuration('Tools','Plot Navigation',true,'Once"
 	      "AtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'V"
-	      "ersion','2017b','Location',[66 78 1921 1079])"
+	      "ersion','2017a','Location',[66 78 1921 1079])"
 	      NumInputPorts	      "4"
 	    }
 	    Block {
@@ -25761,8 +25502,6 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"wL_WBDT"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25786,8 +25525,6 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"wR_WBDT"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -25879,7 +25616,7 @@ Model {
 	      "inedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'TimeRangeSamples','14"
 	      "','TimeRangeFrames','14','DisplayLayoutDimensions',[6 1]),extmgr.Configuration('Tools','Plot Navigation',true,'"
 	      "OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')"
-	      "),'Version','2017b','Location',[76 108 1377 797])"
+	      "),'Version','2017a','Location',[76 108 1377 797])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -25950,7 +25687,7 @@ Model {
 	      "Width',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'Sh"
 	      "owContent',true,'Placement',1),'TimeRangeSamples','40','TimeRangeFrames','40','DisplayLayoutDimensions',[4 1]),"
 	      "extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false),extmgr.Configuration('Tools','Measureme"
-	      "nts',true,'Version','2017b')),'Version','2017b','Location',[66 78 1367 767])"
+	      "nts',true,'Version','2017b')),'Version','2017a','Location',[66 78 1367 767])"
 	      NumInputPorts	      "4"
 	    }
 	    Block {
@@ -26021,7 +25758,7 @@ Model {
 	      "e','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placeme"
 	      "nt',1),'TimeRangeSamples','40','TimeRangeFrames','40','DisplayLayoutDimensions',[4 1]),extmgr.Configuration('To"
 	      "ols','Plot Navigation',true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','201"
-	      "7b')),'Version','2017b','Location',[66 78 1367 767])"
+	      "7b')),'Version','2017a','Location',[66 78 1367 767])"
 	      NumInputPorts	      "4"
 	    }
 	    Block {
@@ -26115,7 +25852,7 @@ Model {
 	      "tyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNa"
 	      "mes',{{[]}},'ShowContent',true,'Placement',1),'TimeRangeSamples','14','TimeRangeFrames','14','DisplayLayoutDime"
 	      "nsions',[6 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY')"
-	      ",extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[355 406 164"
+	      ",extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[355 406 164"
 	      "6 1065])"
 	      NumInputPorts	      "6"
 	    }
@@ -27115,32 +26852,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -27161,32 +26888,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -27244,7 +26961,7 @@ Model {
 	      "35294117647 1 1;1 0.0745098039215686 0.650980392156863]),'DisplayLayoutDimensions',[3 2],'DisplayContentCache',"
 	      "{struct('Title','%<SignalLabel>','LinePropertiesCache',{{}},'UserDefinedChannelNames',{{}},'PlotMagPhase',false"
 	      ")}),extmgr.Configuration('Tools','Plot Navigation',true),extmgr.Configuration('Tools','Measurements',true,'Vers"
-	      "ion','2017b')),'Version','2017b','Position',[403 146 560 420])"
+	      "ion','2017b')),'Version','2017a','Position',[403 146 560 420])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -27302,7 +27019,7 @@ Model {
 	      "294117647 1 1;1 0.0745098039215686 0.650980392156863]),'DisplayLayoutDimensions',[3 2],'DisplayContentCache',{s"
 	      "truct('Title','%<SignalLabel>','LinePropertiesCache',{{}},'UserDefinedChannelNames',{{}},'PlotMagPhase',false)}"
 	      "),extmgr.Configuration('Tools','Plot Navigation',true),extmgr.Configuration('Tools','Measurements',true,'Versio"
-	      "n','2017b')),'Version','2017b','Position',[403 146 560 420])"
+	      "n','2017b')),'Version','2017a','Position',[403 146 560 420])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -27350,7 +27067,7 @@ Model {
 	      " 0],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','Lin"
 	      "eWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'S"
 	      "howContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation'"
-	      ",true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017b"
+	      ",true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017a"
 	      "','Location',[66 78 1367 767])"
 	      NumInputPorts	      "2"
 	    }
@@ -27399,7 +27116,7 @@ Model {
 	      "arker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible',"
 	      "'on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'Displ"
 	      "ayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAuto"
-	      "scale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',"
+	      "scale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',"
 	      "[333 390 1634 1079])"
 	      NumInputPorts	      "2"
 	    }
@@ -27449,7 +27166,7 @@ Model {
 	      ",0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowCont"
 	      "ent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'"
 	      "OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')"
-	      "),'Version','2017b','Location',[1345 525 2656 1244])"
+	      "),'Version','2017a','Location',[1345 525 2656 1244])"
 	      NumInputPorts	      "2"
 	    }
 	    Block {
@@ -27497,7 +27214,7 @@ Model {
 	      ",'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWi"
 	      "dth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'Show"
 	      "Content',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',tr"
-	      "ue,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017b','"
+	      "ue,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017a','"
 	      "Location',[66 78 1367 767])"
 	      NumInputPorts	      "2"
 	    }
@@ -27546,7 +27263,7 @@ Model {
 	      "arker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible',"
 	      "'on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'Displ"
 	      "ayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAuto"
-	      "scale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',"
+	      "scale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',"
 	      "[66 106 1377 825])"
 	      NumInputPorts	      "2"
 	    }
@@ -27596,7 +27313,7 @@ Model {
 	      "-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{"
 	      "[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navi"
 	      "gation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Ver"
-	      "sion','2016b')),'Version','2017b','Location',[66 134 1377 853])"
+	      "sion','2016b')),'Version','2017a','Location',[66 134 1377 853])"
 	      NumInputPorts	      "2"
 	    }
 	    Block {
@@ -27644,7 +27361,7 @@ Model {
 	      ",'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWi"
 	      "dth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'Show"
 	      "Content',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',tr"
-	      "ue,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017b','"
+	      "ue,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017a','"
 	      "Location',[66 78 1367 767])"
 	      NumInputPorts	      "2"
 	    }
@@ -27693,7 +27410,7 @@ Model {
 	      " 0],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','Lin"
 	      "eWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'S"
 	      "howContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation'"
-	      ",true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017b"
+	      ",true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Version','2017b')),'Version','2017a"
 	      "','Location',[66 78 1367 767])"
 	      NumInputPorts	      "2"
 	    }
@@ -28052,32 +27769,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -28098,32 +27805,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -28144,32 +27841,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -28190,32 +27877,22 @@ Model {
 	      Port {
 		PortNumber		1
 		Name			"torso"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		2
 		Name			"left_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		3
 		Name			"right_arm"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		4
 		Name			"left_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	      Port {
 		PortNumber		5
 		Name			"right_leg"
-		RTWStorageClass		"Auto"
-		DataLoggingNameMode	"SignalName"
 	      }
 	    }
 	    Block {
@@ -28348,7 +28025,7 @@ Model {
 	      "t('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{"
 	      "{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2 1]),extmgr.C"
 	      "onfiguration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('"
-	      "Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[66 78 1921 1079])"
+	      "Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 78 1921 1079])"
 	      NumInputPorts	      "2"
 	    }
 	    Block {
@@ -28397,7 +28074,7 @@ Model {
 	      "th',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none',"
 	      "'Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement'"
 	      ",1),'DisplayLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'Pr"
-	      "eviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','"
+	      "eviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','"
 	      "Location',[632 559 1943 1278])"
 	      NumInputPorts	      "2"
 	    }
@@ -28491,7 +28168,7 @@ Model {
 	      "',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'Num"
 	      "Lines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),extmgr.Configura"
 	      "tion('Tools','Plot Navigation',true,'OnceAtStop',false),extmgr.Configuration('Tools','Measurements',true,'Versi"
-	      "on','2017b')),'Version','2017b','Location',[66 78 1367 767])"
+	      "on','2017b')),'Version','2017a','Location',[66 78 1367 767])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -28539,7 +28216,7 @@ Model {
 	      "Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible'"
 	      ",'on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'Disp"
 	      "layLayoutDimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAut"
-	      "oscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location'"
+	      "oscale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location'"
 	      ",[66 78 1921 1079])"
 	      NumInputPorts	      "2"
 	    }
@@ -28635,7 +28312,7 @@ Model {
 	      "',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'Num"
 	      "Lines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),extmgr.Configura"
 	      "tion('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','"
-	      "Measurements',true,'Version','2016b')),'Version','2017b','Location',[66 78 1921 1079])"
+	      "Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 78 1921 1079])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -28730,7 +28407,7 @@ Model {
 	      "lor',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChannelNames',{{}},'"
 	      "NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[6 1]),extmgr.Config"
 	      "uration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools"
-	      "','Measurements',true,'Version','2016b')),'Version','2017b','Location',[431 355 1732 1044])"
+	      "','Measurements',true,'Version','2016b')),'Version','2017a','Location',[431 355 1732 1044])"
 	      NumInputPorts	      "6"
 	    }
 	    Block {
@@ -28824,7 +28501,7 @@ Model {
 	      "rker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','"
 	      "on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'Displa"
 	      "yLayoutDimensions',[6 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutos"
-	      "cale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',["
+	      "cale','XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',["
 	      "512 390 1813 1079])"
 	      NumInputPorts	      "6"
 	    }
@@ -29505,7 +29182,7 @@ Model {
 	      "arker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible',"
 	      "'on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1)),extmg"
 	      "r.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuratio"
-	      "n('Tools','Measurements',true,'Version','2016b')),'Version','2016b','Location',[66 109 1387 858])"
+	      "n('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 109 1387 858])"
 	      NumInputPorts	      "1"
 	    }
 	    Block {
@@ -29545,7 +29222,7 @@ Model {
 	      "'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible"
 	      "','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1)),ext"
 	      "mgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configurat"
-	      "ion('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[640 199 1220 679])"
+	      "ion('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[640 199 1220 679])"
 	      NumInputPorts	      "1"
 	    }
 	    Block {
@@ -29594,7 +29271,7 @@ Model {
 	      "none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},"
 	      "'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayout"
 	      "Dimensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','"
-	      "XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2016b','Location',[66 140 "
+	      "XY'),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 140 "
 	      "1397 919])"
 	      NumInputPorts	      "1"
 	    }
@@ -29644,7 +29321,7 @@ Model {
 	      "','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedCh"
 	      "annelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDimensions',[2"
 	      " 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Co"
-	      "nfiguration('Tools','Measurements',true,'Version','2016b')),'Version','2016b','Location',[76 162 1387 881])"
+	      "nfiguration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[76 162 1387 881])"
 	      NumInputPorts	      "1"
 	    }
 	    Block {
@@ -29693,7 +29370,7 @@ Model {
 	      "e','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'Us"
 	      "erDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1),'DisplayLayoutDim"
 	      "ensions',[2 1]),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'"
-	      "),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2016b','Location',[66 109 138"
+	      "),extmgr.Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[66 109 138"
 	      "7 858])"
 	      NumInputPorts	      "1"
 	    }
@@ -29734,7 +29411,7 @@ Model {
 	      "none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},"
 	      "'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1)),extmgr.Config"
 	      "uration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools"
-	      "','Measurements',true,'Version','2016b')),'Version','2017b','Location',[403 294 943 654])"
+	      "','Measurements',true,'Version','2016b')),'Version','2017a','Location',[403 294 943 654])"
 	      NumInputPorts	      "1"
 	    }
 	    Block {
@@ -29773,7 +29450,7 @@ Model {
 	      ",'Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'User"
 	      "DefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1)),extmgr.Configurati"
 	      "on('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Me"
-	      "asurements',true,'Version','2016b')),'Version','2017b','Location',[655 257 1235 737])"
+	      "asurements',true,'Version','2016b')),'Version','2017a','Location',[655 257 1235 737])"
 	      NumInputPorts	      "1"
 	    }
 	    Block {
@@ -29928,7 +29605,7 @@ Model {
 		  BlockType		  Outport
 		  Name			  "|1-R^T*RDes|^2"
 		  SID			  "6182"
-		  Position		  [802, 8, 832, 22]
+		  Position		  [800, 8, 830, 22]
 		  ZOrder		  38
 		  IconDisplay		  "Port number"
 		}
@@ -30194,7 +29871,7 @@ Model {
 		  BlockType		  Outport
 		  Name			  "|1-R^T*RDes|^2"
 		  SID			  "6186"
-		  Position		  [916, 88, 946, 102]
+		  Position		  [915, 88, 945, 102]
 		  ZOrder		  39
 		  IconDisplay		  "Port number"
 		}
@@ -30460,7 +30137,7 @@ Model {
 		  BlockType		  Outport
 		  Name			  "|1-R^T*RDes|^2"
 		  SID			  "6190"
-		  Position		  [892, 68, 922, 82]
+		  Position		  [890, 68, 920, 82]
 		  ZOrder		  40
 		  IconDisplay		  "Port number"
 		}
@@ -30610,7 +30287,7 @@ Model {
 	      "on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','none','Visible','on')}},'UserDefinedChann"
 	      "elNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placement',1)),extmgr.Configuration('Tools','"
 	      "Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr.Configuration('Tools','Measurements',"
-	      "true,'Version','2016b')),'Version','2017b','Location',[128 253 1439 972])"
+	      "true,'Version','2016b')),'Version','2017a','Location',[128 253 1439 972])"
 	      NumInputPorts	      "1"
 	    }
 	    Block {
@@ -30651,7 +30328,7 @@ Model {
 	      "Width',0.5,'Marker','none','Visible','on'),struct('Color',[0 0 1],'LineStyle','-','LineWidth',0.5,'Marker','non"
 	      "e','Visible','on')}},'UserDefinedChannelNames',{{}},'NumLines',0,'LineNames',{{[]}},'ShowContent',true,'Placeme"
 	      "nt',1)),extmgr.Configuration('Tools','Plot Navigation',true,'OnceAtStop',false,'PreviousAutoscale','XY'),extmgr"
-	      ".Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017b','Location',[660 254 1260 794])"
+	      ".Configuration('Tools','Measurements',true,'Version','2016b')),'Version','2017a','Location',[660 254 1260 794])"
 	      NumInputPorts	      "1"
 	    }
 	    Line {
@@ -31593,13 +31270,13 @@ Model {
 }
 #Finite State Machines
 #
-#   Stateflow 80000010
+#   Stateflow 80000011
 #
 #
 Stateflow {
   machine {
     id			    1
-    name		    "torqueWalkingMPC"
+    name		    "torqueWalkingMPC_R2016b"
     created		    "29-Nov-2017 15:01:26"
     isLibrary		    0
     sfVersion		    80000010

--- a/library/matlab/QPInverseKinematics.m
+++ b/library/matlab/QPInverseKinematics.m
@@ -171,9 +171,10 @@ function QPInverseKinematics(block)
         
         % to avoid the equality constraints to be unfeasible for numerical errors,
         % a small tolerance is added to the bias vectors
-        eps      = [0.001*ones(3,1); 0.1*ones(3,1); ...
-                    0.001*ones(3,1); 0.1*ones(3,1); ...
-                    0.001*ones(3,1); 0.1*ones(3,1)];
+        eps = zeros(size(biasVectorConstraint,1),1);
+        for i = 1:6:size(biasVectorConstraint,1)
+            eps(i:i+5, 1) = [0.001*ones(3,1); 0.1*ones(3,1)];
+        end
                     
         ubA  = biasVectorConstraint+eps;
         lbA  = biasVectorConstraint-eps;


### PR DESCRIPTION
In torqueWalkingMPC/Robot State and References/Smooth References /Smooth Reference Positions,
_smoothingTime_leftFoot_ was used with _s_des_