### PR TITLE
Fix sign in documentation

### DIFF
--- a/controllers/floating-base-balancing-torque-control/src/momentumBasedController.m
+++ b/controllers/floating-base-balancing-torque-control/src/momentumBasedController.m
@@ -169,7 +169,7 @@ function [HessianMatrixOneFoot, gradientOneFoot, ConstraintsMatrixOneFoot, bVect
     %
     % where tau_0 is given by the following equation:
     %
-    %    tau_0 = hs - Msb*invMb*hb + (Js^T - Msb*invMb*Jb^T)*f + u_0
+    %    tau_0 = hs - Msb*invMb*hb - (Js^T - Msb*invMb*Jb^T)*f + u_0
     %
     % where we have:
     %


### PR DESCRIPTION
Accordingly to the theory in https://arxiv.org/pdf/1603.04178.pdf.

The missing 'minus' sign is then recovered in 
https://github.com/robotology/whole-body-controllers/blob/505c244c8985930821f9f0fc4bd855117755650e/controllers/floating-base-balancing-torque-control/src/momentumBasedController.m#L195

and indeed implementation is correct
https://github.com/robotology/whole-body-controllers/blob/505c244c8985930821f9f0fc4bd855117755650e/controllers/floating-base-balancing-torque-control/src/momentumBasedController.m#L277