### PR TITLE
Reimplement rotx roty and rotz in order to be compatible with symbolic variables

### DIFF
--- a/library/matlab-wbc/+wbc/rotx.m
+++ b/library/matlab-wbc/+wbc/rotx.m
@@ -18,11 +18,9 @@ function R = rotx(alpha)
 
     %% --- Initialization ---
 
-   R      =  zeros(3,3);
-   R(1,1) =  1;
-   R(2,2) =  cos(alpha);
-   R(2,3) = -sin(alpha);
-   R(3,2) =  sin(alpha);
-   R(3,3) =  cos(alpha); 
-   
+
+   R =  [1, 0, 0;
+         0, cos(alpha), -sin(alpha);
+         0, sin(alpha), cos(alpha)];
+
 end

--- a/library/matlab-wbc/+wbc/roty.m
+++ b/library/matlab-wbc/+wbc/roty.m
@@ -18,11 +18,8 @@ function R = roty(alpha)
 
     %% --- Initialization ---
 
-   R      =  zeros(3,3);
-   R(2,2) =  1;
-   R(1,1) =  cos(alpha);
-   R(1,3) =  sin(alpha);
-   R(3,1) = -sin(alpha);
-   R(3,3) =  cos(alpha); 
-   
+   R = [cos(alpha), 0, sin(alpha);
+        0, 1, 0;
+        -sin(alpha), 0, cos(alpha)];
+
 end

--- a/library/matlab-wbc/+wbc/rotz.m
+++ b/library/matlab-wbc/+wbc/rotz.m
@@ -18,11 +18,8 @@ function R = rotz(alpha)
 
     %% --- Initialization ---
 
-   R      =  zeros(3,3);
-   R(3,3) =  1;
-   R(1,1) =  cos(alpha);
-   R(1,2) = -sin(alpha);
-   R(2,1) =  sin(alpha);
-   R(2,2) =  cos(alpha); 
+   R = [cos(alpha), -sin(alpha), 0;
+        sin(alpha),  cos(alpha), 0;
+        0,           0,          1];
 
 end


### PR DESCRIPTION
Thanks to this PR it is now possible to use `wbc.rot<x,y,z>()` with a  Matlab symbolic variable as
```matlab
syms theta
A = wbc.rotz(theta)
```

```
A =
 
[cos(theta), -sin(theta), 0]
[sin(theta),  cos(theta), 0]
[         0,           0, 1]
```

cc @gabrielenava 