### PR TITLE
Add VaseRising home pose

### DIFF
--- a/utilities/homePositions/robots/iCubGenova09/homePoseBalancing.ini
+++ b/utilities/homePositions/robots/iCubGenova09/homePoseBalancing.ini
@@ -50,3 +50,19 @@ parts (face head torso left_arm right_arm right_leg left_leg)
 /$robot/right_leg_Velocity       10            10            10            10            10            10
 /$robot/left_leg_Position        0             0             0             0             0              0
 /$robot/left_leg_Velocity        10            10            10            10            10            10
+
+[customPosition_VaseRising]
+/$robot/face_Position            0
+/$robot/face_Velocity            50
+/$robot/head_Position            0             0             0              0             0          0
+/$robot/head_Velocity            10            10            10             10            10         10
+/$robot/torso_Position           0             0             0
+/$robot/torso_Velocity           10            10            10
+/$robot/left_arm_Position       -80            25            8             40           -0.00          0.00         -0.00        15     30      10      0       0       0       10      0       10
+/$robot/left_arm_Velocity        10            10            10            10            30            30            30          10     10      10      10      10      10      10      10      10
+/$robot/right_arm_Position      -80            25            8             40            -0.00          0.00         -0.00        15     30      10      0       0       0       10      0       10
+/$robot/right_arm_Velocity       10            10            10            10            30            30            30          10     10      10      10      10      10      10      10      10
+/$robot/right_leg_Position       12            5             0            -10           -4            -5
+/$robot/right_leg_Velocity       10            10            10            10            10            10
+/$robot/left_leg_Position        12            5             0            -10           -4            -5
+/$robot/left_leg_Velocity        10            10            10            10            10            10


### PR DESCRIPTION
This PR is to add a new home pose for the robot, called `VaseRising` since it is close to the pose in which the robot is rising the vase.

Related issue: ami-iit/component_ANA-Avatar-XPRIZE#564