### PR TITLE
Fix floatingBaseBalancingTorqueControlWithSimulator.torqueControlBalancingWithSimu with contact switch

### DIFF
--- a/controllers/+floatingBaseBalancingTorqueControlWithSimulator/app/robots/iCubGazeboV2_5/configStateMachine.m
+++ b/controllers/+floatingBaseBalancingTorqueControlWithSimulator/app/robots/iCubGazeboV2_5/configStateMachine.m
@@ -50,11 +50,11 @@ StateMachine.initialState                 = 1;
 % other configuration parameters for state machine
 StateMachine.tBalancing                   = 1;
 StateMachine.tBalancingBeforeYoga         = 1;
-StateMachine.yogaExtended                 = true;
+StateMachine.yogaExtended                 = false;
 StateMachine.skipYoga                     = false;
 StateMachine.demoOnlyBalancing            = false;
 StateMachine.demoStartsOnRightSupport     = false; % If false, the Yoga demo is performed on the left foot first
-StateMachine.yogaAlsoOnRightFoot          = false; % TO DO: yoga on both feet starting from right foot (not available for now)
+StateMachine.yogaAlsoOnRightFoot          = true; % TO DO: yoga on both feet starting from right foot
 
 %%%% List of possible "Yoga in loop" %%%%
 

--- a/controllers/+floatingBaseBalancingTorqueControlWithSimulator/initTorqueControlBalancingWithSimu.m
+++ b/controllers/+floatingBaseBalancingTorqueControlWithSimulator/initTorqueControlBalancingWithSimu.m
@@ -38,7 +38,7 @@ addpath(strcat(MODEL_PATH,'/src/'));
 
 % Simulation time in seconds. For long simulations, put an high number 
 % (not inf) for allowing automatic code generation
-Config.SIMULATION_TIME = 600000;
+Config.SIMULATION_TIME = 100;
 
 % Controller period [s]
 Config.tStep           = 0.01;  % 10 ms


### PR DESCRIPTION
Change parameters of  floatingBaseBalancingTorqueControlWithSimulator.torqueControlBalancingWithSimu with the goal of:
* Reduce simulation time (as this is intedended to showcase the controllers+simulators, it does not make sense to do yoga extended)
* Set a fixed simulation time (so we can use it in automatica testing)
* Changing some parameters it seems that contact switching is working fine, so I enable it again to show that the simulation is not running with a feet fixed to the ground

